### PR TITLE
✨ Feat: UIView 속성을 간단하게 처리할 UIViewSetter 구현

### DIFF
--- a/AKCOO.xcodeproj/project.pbxproj
+++ b/AKCOO.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		512579B72CDD16DD00649D3F /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 512579B62CDD16DD00649D3F /* .swiftlint.yml */; };
+		512579BA2CDE43EB00649D3F /* UIView+Setter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512579B92CDE43EB00649D3F /* UIView+Setter.swift */; };
 		F3EB760D2CDD14B20054D4E1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F3EB760C2CDD14B20054D4E1 /* Assets.xcassets */; };
 		F3EB76102CDD14B20054D4E1 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = F3EB760F2CDD14B20054D4E1 /* Base */; };
 		F3EB761B2CDD14B20054D4E1 /* AKCOOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3EB761A2CDD14B20054D4E1 /* AKCOOTests.swift */; };
@@ -86,6 +87,7 @@
 
 /* Begin PBXFileReference section */
 		512579B62CDD16DD00649D3F /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		512579B92CDE43EB00649D3F /* UIView+Setter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Setter.swift"; sourceTree = "<group>"; };
 		F3EB76002CDD14B00054D4E1 /* AKCOO.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AKCOO.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3EB760C2CDD14B20054D4E1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F3EB760F2CDD14B20054D4E1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -409,6 +411,7 @@
 			isa = PBXGroup;
 			children = (
 				F3EB76B22CDDFD850054D4E1 /* UIColor+Hex.swift */,
+				512579B92CDE43EB00649D3F /* UIView+Setter.swift */,
 				F3EB76B42CDE14E60054D4E1 /* UIViewController+HideKeyboard.swift */,
 				F3EB76B62CDE157B0054D4E1 /* SetWindowBackground.swift */,
 			);
@@ -646,6 +649,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F3EB76492CDDDDFF0054D4E1 /* CoordinatorType.swift in Sources */,
+				512579BA2CDE43EB00649D3F /* UIView+Setter.swift in Sources */,
 				F3EB76722CDDE3DF0054D4E1 /* ExpenseSceneController.swift in Sources */,
 				F3EB76672CDDE39A0054D4E1 /* TravelTableView.swift in Sources */,
 				F3EB76B52CDE14E60054D4E1 /* UIViewController+HideKeyboard.swift in Sources */,

--- a/AKCOO/DesignSystem/Extensions/UIView+Setter.swift
+++ b/AKCOO/DesignSystem/Extensions/UIView+Setter.swift
@@ -1,0 +1,29 @@
+//
+//  UIView+Setter.swift
+//  AKCOO
+//
+//  Created by Anjin on 11/8/24.
+//
+
+import UIKit
+
+protocol UIViewSetter {}
+
+extension UIViewSetter where Self: UIView {
+  /// UIView 속성을 설장하기 위한 method
+  ///
+  /// 사용 예시:
+  /// ```swift
+  /// private let spendInputView = UIView().set {
+  ///     $0.backgroundColor = .systemGray5
+  ///     $0.layer.cornerRadius = 20
+  /// }
+  /// ```
+  func set(_ configure: (Self) -> Void = { _ in }) -> Self {
+    configure(self)
+    self.translatesAutoresizingMaskIntoConstraints = false
+    return self
+  }
+}
+
+extension UIView: UIViewSetter {}


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #6 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

UIView 속성을 간단하게 처리할 UIViewSetter를 구현했습니다.
UIViewSetter는 UIView에 확장된 형태입니다.

set method를 활용하는 경우, `translatesAutoresizingMaskIntoConstraints` 설정이 포함되어 있으니 별도로 추가하지 않아도 됩니다.
사용 시에는 아래와 같이 사용해 주세요!
```swift
private let spendInputView = UIView().set {
  $0.backgroundColor = .systemGray5
  $0.layer.cornerRadius = 20
}
```

만약 다른 속성은 추가할 필요 없이 `translatesAutoresizingMaskIntoConstraints` 만 설정하고 싶은 경우에는,
아래와 같이 set method를 실행하기만 해주시면 됩니다.
```swift
private let spendInputView = UIView().set()
```

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->

파이팅 얍

<br>
