### PR TITLE
📃 Chore: SwiftLint 규칙 수정(변수명 길이 제한을 1로 고정)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -30,7 +30,10 @@ opt_in_rules: # Default Rules에서 활성화할 규칙
 indentation_width:
   indentation_width: 2
 
-type_body_length: 
+# 변수명의 최소 길이를 1로 제한합니다 (제한이 없는 것처럼 동작)
+identifier_name:
+  min_length: 1
+
+type_body_length:
   warning: 500
   error: 600
-


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #26 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

SwiftLint 규칙 중, 변수명 길이가 세 글자 이상이어야 하는 기본 설정을 비활성화했습니다.
identifier_name 자체의 비활성화가 아닌, 최소 길이를 1로 두어 제한이 없는 것처럼 동작하도록 했습니다.

<br>