### PR TITLE
📃 Chore: #32 swiftlint type_name 타입 이름 글자 수 제한 비활성화

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,6 +17,9 @@ disabled_rules: # Default Rules에서 비활성화할 규칙
   
   # 튜플의 요소 수 제한 비활성화
   - large_tuple
+  
+  # Type 이름의 글자 수를 제한합니다. https://realm.github.io/SwiftLint/type_name.html
+  - type_name
 
 opt_in_rules: # Default Rules에서 활성화할 규칙
   

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -33,7 +33,7 @@ opt_in_rules: # Default Rules에서 활성화할 규칙
 indentation_width:
   indentation_width: 2
 
-# 변수명의 최소 길이를 1로 제한합니다 (제한이 없는 것처럼 동작)
+# 변수명의 최소 길이를 1로 제한합니다 (제한이 없는 것처럼 동작) https://realm.github.io/SwiftLint/identifier_name.html
 identifier_name:
   min_length: 1
 


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #32 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

![image](https://github.com/user-attachments/assets/e4f824a3-4a6f-48ae-9877-1a894bf92a32)

기존에 추가했던 린트는 변수명에 대한 글자 수 제한이었습니다!
그래서 타입 이름에는 적용되지 않아 린트가 여전히 뜨는 상황이었어요.
그래서 타입 이름 제한을 그냥 비활성화했습니다 ㅎㅎㅎ

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->

빌드하고 린트가 TODO만 남아있는 것까지 확인했는데,
혹시 추가로 오류가 뜨면 알려주세요!

<br>
