### PR TITLE
✨ Feat: 카테고리, 나라에 맞춰 직전 소비 가져오기 구현

### DIFF
--- a/AKCOO/Data/Repository/RecordRepositoryImp.swift
+++ b/AKCOO/Data/Repository/RecordRepositoryImp.swift
@@ -34,7 +34,7 @@ struct RecordRepositoryImp: RecordRepository {
   
   /// 사용자의 직전 소비 기록을 반환
   func fetchPreviousDaySpending(country: String, category: String) -> Result<UserRecord?, any Error> {
-    switch coreData.getLatestUserRecord() {
+    switch coreData.getLatestUserRecord(country: country, category: category) {
     case .success(let success):
       return .success(success)
     case .failure(let error):

--- a/AKCOO/Data/Repository/RecordRepositoryImp.swift
+++ b/AKCOO/Data/Repository/RecordRepositoryImp.swift
@@ -33,7 +33,6 @@ struct RecordRepositoryImp: RecordRepository {
   }
   
   /// 사용자의 직전 소비 기록을 반환
-  //FIXME: category, country를 반영한 최근 소비 기록 가져오기;;;;;; 이걸 잊어버리다니;;;
   func fetchPreviousDaySpending(country: String, category: String) -> Result<UserRecord?, any Error> {
     switch coreData.getLatestUserRecord() {
     case .success(let success):

--- a/AKCOO/Data/Service/CoreDataService.swift
+++ b/AKCOO/Data/Service/CoreDataService.swift
@@ -59,12 +59,18 @@ extension CoreDataService {
   }
   
   /// READ - 가장 최신의 UserRecord 불러오기
-  func getLatestUserRecord() -> Result<UserRecord?, Error> {
+  func getLatestUserRecord(country: String, category: String) -> Result<UserRecord?, Error> {
     let request: NSFetchRequest<UserRecordEntity> = UserRecordEntity.fetchRequest()
     
     // 정렬 조건 추가: date 기준 내림차순 -> 데이터 1개만 가져오기
     request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
     request.fetchLimit = 1
+    
+    // 나라와 카테고리 조건 추가
+    request.predicate = NSPredicate(
+      format: "userQuestion.country.name == %@ AND userQuestion.category == %@",
+      country, category
+    )
     
     do {
       guard let latestEntity = try context.fetch(request).first else {


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #50

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

이전에 작업했던 "직전 소비 기록 가져오기"에서 나라와 카테고리를 반영한 소비를 가져오지 않고 있었습니다.
이에 조건에 맞는 기록을 불러올 수 있도록 기준을 추가했습니다.

<br>