### PR TITLE
✨ Feat: 짹짹이들 판단 문구 변경 반영

### DIFF
--- a/AKCOO/Domain/Entity/Judgmemt/CountryAverageJudgment.swift
+++ b/AKCOO/Domain/Entity/Judgmemt/CountryAverageJudgment.swift
@@ -8,10 +8,8 @@
 import Foundation
 
 struct CountryAverageJudgment: Judgment {
-  var userAmount: Double
+  var userQuestion: UserQuestion
   var standards: [Item]
-  var userQuestion: UserQuestion?
-  
   var name: String { return "평균" }
   var result: JudgmentType {
     guard let average = averageOfItems else { return .notBuying }
@@ -21,6 +19,10 @@ struct CountryAverageJudgment: Judgment {
     } else {
       return .notBuying
     }
+  }
+  
+  var userAmount: Double {
+    return userQuestion.amount
   }
 }
 

--- a/AKCOO/Domain/Entity/Judgmemt/CountryAverageJudgment.swift
+++ b/AKCOO/Domain/Entity/Judgmemt/CountryAverageJudgment.swift
@@ -10,6 +10,7 @@ import Foundation
 struct CountryAverageJudgment: Judgment {
   var userAmount: Double
   var standards: [Item]
+  var userQuestion: UserQuestion?
   
   var name: String { return "평균" }
   var result: JudgmentType {

--- a/AKCOO/Domain/Entity/Judgmemt/PreviousJudgment.swift
+++ b/AKCOO/Domain/Entity/Judgmemt/PreviousJudgment.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct PreviousJudgment: Judgment {
-  var userAmount: Double
+  var userQuestion: UserQuestion
   var standards: UserRecord?
   
   var name: String { return "직전 소비" }
@@ -20,6 +20,6 @@ struct PreviousJudgment: Judgment {
       return .buying
     }
     
-    return userAmount <= userRecordAmount ? .buying : .notBuying
+    return userQuestion.amount <= userRecordAmount ? .buying : .notBuying
   }
 }

--- a/AKCOO/Domain/Entity/Judgmemt/Protocol/Judgment.swift
+++ b/AKCOO/Domain/Entity/Judgmemt/Protocol/Judgment.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol Judgment {
   associatedtype Standards
   var name: String { get }
-  var userAmount: Double { get set }
+  var userQuestion: UserQuestion { get set }
   var standards: Standards { get set }
   var result: JudgmentType { get }
 }

--- a/AKCOO/Domain/UseCase/Interface/Mock/JudgmentUseCaseMock.swift
+++ b/AKCOO/Domain/UseCase/Interface/Mock/JudgmentUseCaseMock.swift
@@ -114,6 +114,7 @@ class JudgmentUseCaseMock: JudgmentUseCase {
         judgment: forignJudgment
       ),
       LocalBird(
+        userQuestion: userQuestion,
         country: country,
         judgment: localJudgment
       ),

--- a/AKCOO/Domain/UseCase/Interface/Mock/JudgmentUseCaseMock.swift
+++ b/AKCOO/Domain/UseCase/Interface/Mock/JudgmentUseCaseMock.swift
@@ -109,17 +109,12 @@ class JudgmentUseCaseMock: JudgmentUseCase {
     )
     
     let birds: [BirdModel] = [
-      ForeignBird(
-        birdCountry: country,
-        judgment: forignJudgment
-      ),
+      ForeignBird(judgment: forignJudgment),
       LocalBird(
         birdCountry: country,
         judgment: localJudgment
       ),
-      PreviousBird(
-        judgment: previousJudgment
-      )
+      PreviousBird(judgment: previousJudgment)
     ]
     
     return .success(birds)

--- a/AKCOO/Domain/UseCase/Interface/Mock/JudgmentUseCaseMock.swift
+++ b/AKCOO/Domain/UseCase/Interface/Mock/JudgmentUseCaseMock.swift
@@ -110,7 +110,7 @@ class JudgmentUseCaseMock: JudgmentUseCase {
     
     let birds: [BirdModel] = [
       ForeignBird(
-        country: country,
+        birdCountry: country,
         judgment: forignJudgment
       ),
       LocalBird(

--- a/AKCOO/Domain/UseCase/Interface/Mock/JudgmentUseCaseMock.swift
+++ b/AKCOO/Domain/UseCase/Interface/Mock/JudgmentUseCaseMock.swift
@@ -95,17 +95,17 @@ class JudgmentUseCaseMock: JudgmentUseCase {
     let userQuestionAmount = userQuestion.amount
     
     let forignJudgment = CountryAverageJudgment(
-      userAmount: userQuestionAmount,
+      userQuestion: userQuestion,
       standards: selectedCountryDetail.items
     )
     let localJudgment = CountryAverageJudgment(
-      userAmount: userQuestionAmount,
+      userQuestion: userQuestion,
       standards: localCountryDetail.items
     )
     
     let previousJudgment = PreviousJudgment(
-      userAmount: userQuestionAmount,
-      standards: previousRecord
+      userQuestion: userQuestion,
+      standards: nil
     )
     
     let birds: [BirdModel] = [
@@ -114,13 +114,10 @@ class JudgmentUseCaseMock: JudgmentUseCase {
         judgment: forignJudgment
       ),
       LocalBird(
-        userQuestion: userQuestion,
-        country: country,
+        birdCountry: country,
         judgment: localJudgment
       ),
-      
       PreviousBird(
-        userQuestion: userQuestion,
         judgment: previousJudgment
       )
     ]

--- a/AKCOO/Domain/UseCase/JudgmentUseCaseImp.swift
+++ b/AKCOO/Domain/UseCase/JudgmentUseCaseImp.swift
@@ -102,17 +102,12 @@ class JudgmentUseCaseImp: JudgmentUseCase {
     )
     
     let birds: [BirdModel] = [
-      ForeignBird(
-        birdCountry: country,
-        judgment: forignJudgment
-      ),
+      ForeignBird(judgment: forignJudgment),
       LocalBird(
         birdCountry: country,
         judgment: localJudgment
       ),
-      PreviousBird(
-        judgment: previousJudgment
-      )
+      PreviousBird(judgment: previousJudgment)
     ]
     
     return .success(birds)

--- a/AKCOO/Domain/UseCase/JudgmentUseCaseImp.swift
+++ b/AKCOO/Domain/UseCase/JudgmentUseCaseImp.swift
@@ -107,6 +107,7 @@ class JudgmentUseCaseImp: JudgmentUseCase {
         judgment: forignJudgment
       ),
       LocalBird(
+        userQuestion: userQuestion,
         country: country,
         judgment: localJudgment
       ),

--- a/AKCOO/Domain/UseCase/JudgmentUseCaseImp.swift
+++ b/AKCOO/Domain/UseCase/JudgmentUseCaseImp.swift
@@ -88,17 +88,17 @@ class JudgmentUseCaseImp: JudgmentUseCase {
     let userQuestionAmount = userQuestion.amount
     
     let forignJudgment = CountryAverageJudgment(
-      userAmount: userQuestionAmount,
+      userQuestion: userQuestion,
       standards: selectedCountryDetail.items
     )
     let localJudgment = CountryAverageJudgment(
-      userAmount: userQuestionAmount,
+      userQuestion: userQuestion,
       standards: localCountryDetail.items
     )
     
     let previousJudgment = PreviousJudgment(
-      userAmount: userQuestionAmount,
-      standards: previousRecord
+      userQuestion: userQuestion,
+      standards: nil
     )
     
     let birds: [BirdModel] = [
@@ -107,13 +107,10 @@ class JudgmentUseCaseImp: JudgmentUseCase {
         judgment: forignJudgment
       ),
       LocalBird(
-        userQuestion: userQuestion,
-        country: country,
+        birdCountry: country,
         judgment: localJudgment
       ),
-      
       PreviousBird(
-        userQuestion: userQuestion,
         judgment: previousJudgment
       )
     ]

--- a/AKCOO/Domain/UseCase/JudgmentUseCaseImp.swift
+++ b/AKCOO/Domain/UseCase/JudgmentUseCaseImp.swift
@@ -103,7 +103,7 @@ class JudgmentUseCaseImp: JudgmentUseCase {
     
     let birds: [BirdModel] = [
       ForeignBird(
-        country: country,
+        birdCountry: country,
         judgment: forignJudgment
       ),
       LocalBird(

--- a/AKCOO/Domain/ViewModel/Bird/BirdGenerator/BirdJudgmentGenerator+getDetail.swift
+++ b/AKCOO/Domain/ViewModel/Bird/BirdGenerator/BirdJudgmentGenerator+getDetail.swift
@@ -12,6 +12,10 @@ extension BirdJudgmentGenerator {
   func getDetail(country: CountryProfile, judgmentCriteria: CountryAverageJudgment) -> String {
     var result = ""
     
+    if let category = judgmentCriteria.standards.first?.category, category == "카페" {
+      result += "아메리카노 기준,\n"
+    }
+    
     result += getDetailAboutAverage(
       country: country,
       judgmentCriteria: judgmentCriteria

--- a/AKCOO/Domain/ViewModel/Bird/BirdGenerator/ForeignBirdJudgmentGenerator.swift
+++ b/AKCOO/Domain/ViewModel/Bird/BirdGenerator/ForeignBirdJudgmentGenerator.swift
@@ -13,8 +13,8 @@ struct ForeignBirdJudgmentGenerator: BirdJudgmentGenerator {
     
     switch reaction {
     case .strongYes:
-      if let category, ["숙박", "식당", "카페"].contains(category) {
-        // 카테고리가 숙박, 식당, 카페인 경우
+      if let category, ["숙소", "식당", "카페"].contains(category) {
+        // 카테고리가 숙소, 식당, 카페인 경우
         return "뭘 고민해! 무조건 가야지"
       } else {
         // 카테고리가 기타이거나 없는 경우

--- a/AKCOO/Domain/ViewModel/Bird/BirdGenerator/ForeignBirdJudgmentGenerator.swift
+++ b/AKCOO/Domain/ViewModel/Bird/BirdGenerator/ForeignBirdJudgmentGenerator.swift
@@ -25,7 +25,7 @@ struct ForeignBirdJudgmentGenerator: BirdJudgmentGenerator {
       return "이 가격이면 나쁘지 않아"
       
     case .weakYes:
-      return "현지에서도 저렴한 금액이야"
+      return "현지에서도 저렴한 가격이야"
       
     case .weakNo:
       return "음.. 조금 비싼데!?"

--- a/AKCOO/Domain/ViewModel/Bird/BirdGenerator/LocalBirdJudgmentGenerator.swift
+++ b/AKCOO/Domain/ViewModel/Bird/BirdGenerator/LocalBirdJudgmentGenerator.swift
@@ -26,7 +26,7 @@ struct LocalBirdJudgmentGenerator: BirdJudgmentGenerator {
       
     case .mediumNo:
       if let category {
-        if category == "숙박" {
+        if category == "숙소" {
           return "차라리 한국에서 호캉스 어때?"
         } else {
           return "차라리 한국에서 \(category) 어때?"

--- a/AKCOO/Domain/ViewModel/Bird/BirdGenerator/LocalBirdJudgmentGenerator.swift
+++ b/AKCOO/Domain/ViewModel/Bird/BirdGenerator/LocalBirdJudgmentGenerator.swift
@@ -19,7 +19,7 @@ struct LocalBirdJudgmentGenerator: BirdJudgmentGenerator {
       return "한국에서도 저렴한 가격이야"
       
     case .weakYes:
-      return "안 사면 한국 가서 후회할걸?"
+      return "한국이랑 비슷한 편이야"
       
     case .weakNo:
       return "한국보다 조금 비싼 편이야"

--- a/AKCOO/Domain/ViewModel/Bird/ForeignBird.swift
+++ b/AKCOO/Domain/ViewModel/Bird/ForeignBird.swift
@@ -14,10 +14,10 @@ struct ForeignBird: BirdModel {
   private let judgmentGenerator: BirdJudgmentGenerator
 
   init(
-    country: CountryProfile,
+    birdCountry: CountryProfile,
     judgment: CountryAverageJudgment
   ) {
-    self.country = country
+    self.country = birdCountry
     self.judgmentCriteria = judgment
     self.judgmentGenerator = ForeignBirdJudgmentGenerator()
   }

--- a/AKCOO/Domain/ViewModel/Bird/ForeignBird.swift
+++ b/AKCOO/Domain/ViewModel/Bird/ForeignBird.swift
@@ -9,17 +9,18 @@ import Foundation
 
 /// 물가를 기준하는 새
 struct ForeignBird: BirdModel {
-  private let country: CountryProfile
   private let judgmentCriteria: CountryAverageJudgment
   private let judgmentGenerator: BirdJudgmentGenerator
 
   init(
-    birdCountry: CountryProfile,
     judgment: CountryAverageJudgment
   ) {
-    self.country = birdCountry
     self.judgmentCriteria = judgment
     self.judgmentGenerator = ForeignBirdJudgmentGenerator()
+  }
+  
+  private var country: CountryProfile {
+    return judgmentCriteria.userQuestion.country
   }
   
   var criteriaName: String { return judgmentCriteria.name }

--- a/AKCOO/Domain/ViewModel/Bird/LocalBird.swift
+++ b/AKCOO/Domain/ViewModel/Bird/LocalBird.swift
@@ -9,21 +9,18 @@ import Foundation
 
 /// 한국 물가를 기준하는 새
 struct LocalBird: BirdModel {
-  private let country: CountryProfile
-  var judgmentCriteria: CountryAverageJudgment
+  private let birdCountry: CountryProfile
+  private var judgmentCriteria: CountryAverageJudgment
+  
   private let judgmentGenerator: BirdJudgmentGenerator
   
   init(
-    /// 사용자가 입력한  판단 요청 정보
-    userQuestion: UserQuestion,
-    /// 새의 국적
-    country: CountryProfile,
-    /// 판단을 위한 정보
-    judgment: CountryAverageJudgment
+    birdCountry: CountryProfile,     // 새의 국적
+    judgment: CountryAverageJudgment // 판단을 위한 정보
   ) {
-    self.country = country
+    self.birdCountry = birdCountry
     self.judgmentCriteria = judgment
-    self.judgmentCriteria.userQuestion = userQuestion
+    
     self.judgmentGenerator = LocalBirdJudgmentGenerator()
   }
   
@@ -33,12 +30,21 @@ struct LocalBird: BirdModel {
   var name: String { return "한국 토박이" }
   var information: String { return "나는 한국 토박이야!" }
   
+  private var userQuestion: UserQuestion {
+    return judgmentCriteria.userQuestion
+  }
+  
   private var convertedToKRWJudgmentCriteria: CountryAverageJudgment {
-    var judgmentCriteria = self.judgmentCriteria
-    if let unit = judgmentCriteria.userQuestion?.country.currency.unit {
-      judgmentCriteria.userAmount *= unit
-    }
-    return judgmentCriteria
+    let crieteria: CountryAverageJudgment = .init(
+      userQuestion: .init(
+        country: userQuestion.country,
+        category: userQuestion.category,
+        amount: userQuestion.amount * userQuestion.country.currency.unit
+      ),
+      standards: judgmentCriteria.standards
+    )
+    
+    return crieteria
   }
   
   private var birdReaction: BirdReaction {
@@ -62,7 +68,7 @@ struct LocalBird: BirdModel {
   var detail: String {
     return judgmentGenerator
       .getDetail(
-        country: self.country,
+        country: self.birdCountry,
         judgmentCriteria: self.convertedToKRWJudgmentCriteria
       )
   }

--- a/AKCOO/Domain/ViewModel/Bird/LocalBird.swift
+++ b/AKCOO/Domain/ViewModel/Bird/LocalBird.swift
@@ -14,8 +14,11 @@ struct LocalBird: BirdModel {
   private let judgmentGenerator: BirdJudgmentGenerator
   
   init(
+    /// 사용자가 입력한  판단 요청 정보
     userQuestion: UserQuestion,
+    /// 새의 국적
     country: CountryProfile,
+    /// 판단을 위한 정보
     judgment: CountryAverageJudgment
   ) {
     self.country = country

--- a/AKCOO/Domain/ViewModel/Bird/LocalBird.swift
+++ b/AKCOO/Domain/ViewModel/Bird/LocalBird.swift
@@ -28,17 +28,25 @@ struct LocalBird: BirdModel {
   var name: String { return "한국 토박이" }
   var information: String { return "나는 한국 토박이야!" }
   
+  private var convertedToKRWJudgmentCriteria: CountryAverageJudgment {
+    var judgmentCriteria = self.judgmentCriteria
+    if let unit = judgmentCriteria.userQuestion?.country.currency.unit {
+      judgmentCriteria.userAmount *= unit
+    }
+    return judgmentCriteria
+  }
+  
   private var birdReaction: BirdReaction {
     return judgmentGenerator
       .getReaction(
-        judgmentCriteria: self.judgmentCriteria
+        judgmentCriteria: self.convertedToKRWJudgmentCriteria
       )
   }
   
   var opinion: String {
     return judgmentGenerator
       .getOpinion(
-        judgmentCriteria: self.judgmentCriteria,
+        judgmentCriteria: self.convertedToKRWJudgmentCriteria,
         reaction: self.birdReaction
       )
   }
@@ -47,7 +55,7 @@ struct LocalBird: BirdModel {
     return judgmentGenerator
       .getDetail(
         country: self.country,
-        judgmentCriteria: self.judgmentCriteria
+        judgmentCriteria: self.convertedToKRWJudgmentCriteria
       )
   }
 }

--- a/AKCOO/Domain/ViewModel/Bird/LocalBird.swift
+++ b/AKCOO/Domain/ViewModel/Bird/LocalBird.swift
@@ -14,11 +14,13 @@ struct LocalBird: BirdModel {
   private let judgmentGenerator: BirdJudgmentGenerator
   
   init(
+    userQuestion: UserQuestion,
     country: CountryProfile,
     judgment: CountryAverageJudgment
   ) {
     self.country = country
     self.judgmentCriteria = judgment
+    self.judgmentCriteria.userQuestion = userQuestion
     self.judgmentGenerator = LocalBirdJudgmentGenerator()
   }
   
@@ -44,6 +46,9 @@ struct LocalBird: BirdModel {
   }
   
   var opinion: String {
+    
+    print(convertedToKRWJudgmentCriteria)
+    
     return judgmentGenerator
       .getOpinion(
         judgmentCriteria: self.convertedToKRWJudgmentCriteria,

--- a/AKCOO/Domain/ViewModel/Bird/PreviousBird.swift
+++ b/AKCOO/Domain/ViewModel/Bird/PreviousBird.swift
@@ -10,24 +10,19 @@ import Foundation
 /// 직전 소비를 기준하는 새
 struct PreviousBird: BirdModel {
   private let judgmentCriteria: PreviousJudgment
-  private let userQuestion: UserQuestion
   
-  init(userQuestion: UserQuestion, judgment: PreviousJudgment) {
-    self.userQuestion = userQuestion
+  init(judgment: PreviousJudgment) {
     self.judgmentCriteria = judgment
   }
   
   var criteriaName: String { return judgmentCriteria.name }
   var judgment: Bool { return judgmentCriteria.result == .buying }
-
-  private var birdReaction: BirdReaction { return .mediumNo }
   
   var name: String { "지난 날의 나" }
   var information: String { return "직전 소비로만 판단해!" }
   
-  private var previousUserRecord: UserRecord? {
-    return judgmentCriteria.standards
-  }
+  private var userQuestion: UserQuestion { return judgmentCriteria.userQuestion }
+  private var previousUserRecord: UserRecord? { return judgmentCriteria.standards }
   
   var opinion: String {
     if let previousUserRecord {
@@ -57,12 +52,14 @@ struct PreviousBird: BirdModel {
   
   var detail: String {
     if let previousUserRecord {
-      let unitTitle = userQuestion.country.currency.unitTitle
+      let unitTitle = userQuestion.country.currency.unitTitle  // 요청한 통화 (ouput: "원")
+      let category = userQuestion.category                     // 요청한 카테고리 (ouput: "숙소")
       
-      let dateString = previousUserRecord.date.toCompactKoreanDateString()
-      let previousAmount = previousUserRecord.amount.formattedWithCommas()
-      let difference = previousUserRecord.amount - userQuestion.amount
-      let absoluteDifference = abs(difference).formattedWithCommas()
+      let dateString = previousUserRecord.date.toCompactKoreanDateString()  // 직전 소비 날짜 (output: "24년 11월 11일")
+      
+      let previousAmount = previousUserRecord.amount.formattedWithCommas()  // 직전 소비 값
+      let difference = previousUserRecord.amount - userQuestion.amount      // 직전 소비와 입력 값의 차이
+      let absoluteDifference = abs(difference).formattedWithCommas()        // 차이의 절댓값
       
       if difference < 0 {
         return "\(dateString)에 '\(previousUserRecord.userJudgment.rawValue)' 버튼을 누른\n<\(userQuestion.category)> \(previousAmount)\(unitTitle)보다\n약 \(absoluteDifference)\(unitTitle) 저렴해요!\n다음에도 비교해서 알려드릴게요."

--- a/AKCOO/Domain/ViewModel/Bird/PreviousBird.swift
+++ b/AKCOO/Domain/ViewModel/Bird/PreviousBird.swift
@@ -51,7 +51,7 @@ struct PreviousBird: BirdModel {
       }
     } else {
       // 직전 소비 판단이 없을 때
-      return "아직 비교할 금액이 없어요"
+      return "아직 비교할 금액이 없어"
     }
   }
   

--- a/AKCOO/Scene/JudgmentScene/Controller/JudgmentCompletedViewController.swift
+++ b/AKCOO/Scene/JudgmentScene/Controller/JudgmentCompletedViewController.swift
@@ -129,6 +129,7 @@ extension JudgmentCompletedViewController: JudgmentEditViewControllerDelegate {
       judgment: forignJudgment
     ),
     LocalBird(
+      userQuestion: userQuestion,
       country: country,
       judgment: localJudgment
     ),

--- a/AKCOO/Scene/JudgmentScene/Controller/JudgmentCompletedViewController.swift
+++ b/AKCOO/Scene/JudgmentScene/Controller/JudgmentCompletedViewController.swift
@@ -124,17 +124,12 @@ extension JudgmentCompletedViewController: JudgmentEditViewControllerDelegate {
   )
   
   let birds: [BirdModel] = [
-    ForeignBird(
-      birdCountry: country,
-      judgment: forignJudgment
-    ),
+    ForeignBird(judgment: forignJudgment),
     LocalBird(
       birdCountry: country,
       judgment: localJudgment
     ),
-    PreviousBird(
-      judgment: previousJudgment
-    )
+    PreviousBird(judgment: previousJudgment)
   ]
   
   return JudgmentCompletedViewController(

--- a/AKCOO/Scene/JudgmentScene/Controller/JudgmentCompletedViewController.swift
+++ b/AKCOO/Scene/JudgmentScene/Controller/JudgmentCompletedViewController.swift
@@ -125,7 +125,7 @@ extension JudgmentCompletedViewController: JudgmentEditViewControllerDelegate {
   
   let birds: [BirdModel] = [
     ForeignBird(
-      country: country,
+      birdCountry: country,
       judgment: forignJudgment
     ),
     LocalBird(

--- a/AKCOO/Scene/JudgmentScene/Controller/JudgmentCompletedViewController.swift
+++ b/AKCOO/Scene/JudgmentScene/Controller/JudgmentCompletedViewController.swift
@@ -110,16 +110,16 @@ extension JudgmentCompletedViewController: JudgmentEditViewControllerDelegate {
   )
   
   let forignJudgment = CountryAverageJudgment(
-    userAmount: userQuestionAmount,
+    userQuestion: userQuestion,
     standards: items
   )
   let localJudgment = CountryAverageJudgment(
-    userAmount: userQuestionAmount,
+    userQuestion: userQuestion,
     standards: items
   )
   
   let previousJudgment = PreviousJudgment(
-    userAmount: userQuestionAmount,
+    userQuestion: userQuestion,
     standards: nil
   )
   
@@ -129,12 +129,10 @@ extension JudgmentCompletedViewController: JudgmentEditViewControllerDelegate {
       judgment: forignJudgment
     ),
     LocalBird(
-      userQuestion: userQuestion,
-      country: country,
+      birdCountry: country,
       judgment: localJudgment
     ),
     PreviousBird(
-      userQuestion: userQuestion,
       judgment: previousJudgment
     )
   ]

--- a/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/BirdReactionCell.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/BirdReactionCell.swift
@@ -119,13 +119,6 @@ class BirdReactionCell: UICollectionViewCell {
 
   birdCell.configure(
     bird: ForeignBird.init(
-      birdCountry: .init(
-        name: "베트남",
-        currency: .init(
-          unitTitle: "동",
-          unit: 0.0589
-        )
-      ),
       judgment: .init(
         userQuestion: .init(
           country: .init(

--- a/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/BirdReactionCell.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/BirdReactionCell.swift
@@ -119,7 +119,7 @@ class BirdReactionCell: UICollectionViewCell {
 
   birdCell.configure(
     bird: ForeignBird.init(
-      country: .init(name: "베트남", currency: .init(unitTitle: "동", unit: 0.0589)),
+      birdCountry: .init(name: "베트남", currency: .init(unitTitle: "동", unit: 0.0589)),
       judgment: .init(userAmount: 5000, standards: [])
     ),
     userAmount: 5000,

--- a/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/BirdReactionCell.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/BirdReactionCell.swift
@@ -119,8 +119,29 @@ class BirdReactionCell: UICollectionViewCell {
 
   birdCell.configure(
     bird: ForeignBird.init(
-      birdCountry: .init(name: "베트남", currency: .init(unitTitle: "동", unit: 0.0589)),
-      judgment: .init(userAmount: 5000, standards: [])
+      birdCountry: .init(
+        name: "베트남",
+        currency: .init(
+          unitTitle: "동",
+          unit: 0.0589
+        )
+      ),
+      judgment: .init(
+        userQuestion: .init(
+          country: .init(
+            name: "베트남",
+            currency: .init(
+              unitTitle: "동",
+              unit: 0.0589
+            )
+          ),
+          category: "숙소", 
+          amount: 5000
+        ),
+        standards: [
+          .init(category: "숙소", name: "3성급", amount: 3000)
+        ]
+      )
     ),
     userAmount: 5000,
     birdImageType: .foriegn

--- a/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/Components/BirdReactionTextView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/Components/BirdReactionTextView.swift
@@ -239,7 +239,7 @@ class BirdReactionTextView: UIView {
   let preview = BirdReactionTextView()
   preview.configure(
     bird: ForeignBird.init(
-      country: .init(name: "베트남", currency: .init(unitTitle: "동", unit: 0.0589)),
+      birdCountry: .init(name: "베트남", currency: .init(unitTitle: "동", unit: 0.0589)),
       judgment: .init(userAmount: 5000, standards: [])
     )
   )

--- a/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/Components/BirdReactionTextView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/Components/BirdReactionTextView.swift
@@ -239,8 +239,29 @@ class BirdReactionTextView: UIView {
   let preview = BirdReactionTextView()
   preview.configure(
     bird: ForeignBird.init(
-      birdCountry: .init(name: "베트남", currency: .init(unitTitle: "동", unit: 0.0589)),
-      judgment: .init(userAmount: 5000, standards: [])
+      birdCountry: .init(
+        name: "베트남",
+        currency: .init(
+          unitTitle: "동",
+          unit: 0.0589
+        )
+      ),
+      judgment: .init(
+        userQuestion: .init(
+          country: .init(
+            name: "베트남",
+            currency: .init(
+              unitTitle: "동",
+              unit: 0.0589
+            )
+          ),
+          category: "숙소",
+          amount: 5000
+        ),
+        standards: [
+          .init(category: "숙소", name: "3성급", amount: 3000)
+        ]
+      )
     )
   )
   

--- a/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/Components/BirdReactionTextView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCell/Components/BirdReactionTextView.swift
@@ -239,13 +239,6 @@ class BirdReactionTextView: UIView {
   let preview = BirdReactionTextView()
   preview.configure(
     bird: ForeignBird.init(
-      birdCountry: .init(
-        name: "베트남",
-        currency: .init(
-          unitTitle: "동",
-          unit: 0.0589
-        )
-      ),
       judgment: .init(
         userQuestion: .init(
           country: .init(

--- a/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCollectionView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCollectionView.swift
@@ -153,6 +153,17 @@ extension BirdReactionCollectionView: UICollectionViewDelegateFlowLayout {
   preview.configure(
     with: [
       LocalBird(
+        userQuestion: UserQuestion(
+          country: CountryProfile(
+            name: "베트남",
+            currency: Currency(
+              unitTitle: "동",
+              unit: 0.055
+            )
+          ),
+          category: "숙소",
+          amount: 1000000
+        ),
         country: .init(
           name: "대한민국",
           currency: .init(

--- a/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCollectionView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Reaction/BirdReactionCollectionView.swift
@@ -153,26 +153,26 @@ extension BirdReactionCollectionView: UICollectionViewDelegateFlowLayout {
   preview.configure(
     with: [
       LocalBird(
-        userQuestion: UserQuestion(
-          country: CountryProfile(
-            name: "베트남",
-            currency: Currency(
-              unitTitle: "동",
-              unit: 0.055
-            )
-          ),
-          category: "숙소",
-          amount: 1000000
-        ),
-        country: .init(
-          name: "대한민국",
-          currency: .init(
+        birdCountry: .init(
+          name: "한국",
+          currency: Currency(
             unitTitle: "원",
             unit: 1
           )
         ),
         judgment: .init(
-          userAmount: 30000, standards: [ ]
+          userQuestion: .init(
+            country: .init(
+              name: "베트남",
+              currency: .init(
+                unitTitle: "동",
+                unit: 0.055
+              )
+            ),
+            category: "숙소",
+            amount: 300000
+          ),
+          standards: [ ]
         )
       )
     ], 


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #55 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

- 짹짹이들의 문구 중 '금액'으로 쓰여있는 부분 중 일부를 '가격'으로 변경했습니다.

- 카테고리명을 '숙박'에서 '숙소'로 변경했습니다.

- 카테고리가 '카페'인 경우, 문구 앞에 '아메리카노 기준,'을 추가했습니다.

- 한국짹일 때 원화로 변환 후 계산하여 적용하도록 수정했습니다. 이 때 사용자의 판단하고자 했던 나라 정보가 필요해 `CountryAverageJudgment`가 `UserQuestion`을 가질 수 있도록 추가했습니다. 해외쨱은 필요하지 않기 때문에 CountryAverageJudgment는 UserQuestion을 Optional로 가지게 됩니다. 그래서 LocalBird가 필수로 UserQuestion을 가져오도록 구현했습니다.
  ```swift
  /// 한국 물가를 기준하는 새
  struct LocalBird: BirdModel {
    private let country: CountryProfile
    var judgmentCriteria: CountryAverageJudgment
    private let judgmentGenerator: BirdJudgmentGenerator
    
    init(
      /// 사용자가 입력한  판단 요청 정보
      userQuestion: UserQuestion,
      /// 새의 국적
      country: CountryProfile,
      /// 판단을 위한 정보
      judgment: CountryAverageJudgment
    ) {
      self.country = country
      self.judgmentCriteria = judgment
      self.judgmentCriteria.userQuestion = userQuestion
      self.judgmentGenerator = LocalBirdJudgmentGenerator()
    }
  
  ...

  ```
  다만 여기서 CountryJudgment가 UserQuestion을 가지고 있는데, 별개로 받아오는 것이 어색하다고 느껴져.. 이제 수정하려고 합니다 ㅎㅎ

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
- Judgment 변경 사항이 있습니다!
기존에 가지고 있던 userAmount를 삭제하고, userQuestion을 가지도록 변경했습니다.

<br>
