### PR TITLE
✨Feat: JudgmentReadyViewController, UserInfoViewController 뒤로가기 버튼

### DIFF
--- a/AKCOO.xcodeproj/project.pbxproj
+++ b/AKCOO.xcodeproj/project.pbxproj
@@ -653,8 +653,8 @@
 		F3EB763F2CDDDDAD0054D4E1 /* Scene */ = {
 			isa = PBXGroup;
 			children = (
-				F36F1A4B2CFCABAD00DD59F8 /* UserInfoScene */,
 				F36F1A2C2CFC73E800DD59F8 /* GuideScene */,
+				F36F1A4B2CFCABAD00DD59F8 /* UserInfoScene */,
 				F3ED92742CE38B8800CF5238 /* JudgmentScene */,
 				F3EB76422CDDDDD10054D4E1 /* Common */,
 			);

--- a/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinatorImp.swift
+++ b/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinatorImp.swift
@@ -31,6 +31,7 @@ class GuideCoordinatorImp: GuideCoordinator, UserInfoCoordinator {
   
   func start() {
     let guideViewController = guideFactory.create(coordinator: self)
+    guideViewController.navigationItem.backButtonTitle = ""
     navigationController.view.backgroundColor = .akColor(.akGray100)
     self.navigationController.viewControllers = [guideViewController]
   }
@@ -44,6 +45,7 @@ class GuideCoordinatorImp: GuideCoordinator, UserInfoCoordinator {
   func startUserInfo() {
     let userViewController = userInfoFactory.create(coordinator: self)
     userViewController.view.backgroundColor = .akColor(.akGray100)
+    self.navigationController.navigationBar.tintColor = .black
     self.navigationController.pushViewController(userViewController, animated: true)
   }
   

--- a/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinatorImp.swift
+++ b/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinatorImp.swift
@@ -32,6 +32,7 @@ class GuideCoordinatorImp: GuideCoordinator, UserInfoCoordinator {
   func start() {
     let guideViewController = guideFactory.create(coordinator: self)
     guideViewController.navigationItem.backButtonTitle = ""
+    navigationController.navigationBar.tintColor = .black
     navigationController.view.backgroundColor = .akColor(.akGray100)
     self.navigationController.viewControllers = [guideViewController]
   }
@@ -45,7 +46,6 @@ class GuideCoordinatorImp: GuideCoordinator, UserInfoCoordinator {
   func startUserInfo() {
     let userViewController = userInfoFactory.create(coordinator: self)
     userViewController.view.backgroundColor = .akColor(.akGray100)
-    self.navigationController.navigationBar.tintColor = .black
     self.navigationController.pushViewController(userViewController, animated: true)
   }
   

--- a/AKCOO/Scene/JudgmentScene/Controller/JudgmentReadyViewController.swift
+++ b/AKCOO/Scene/JudgmentScene/Controller/JudgmentReadyViewController.swift
@@ -48,6 +48,10 @@ class JudgmentReadyViewController: UIViewController {
   }
   
   private func setupViews() {
+    judgmentReadyView.onActionTappedClosedButton = { [weak self] in
+      guard let self else { return }
+      coordinator?.completedJudgment(judgmentViewController: self)
+    }
     judgmentReadyView.paper.readyButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tappedReadyButton)))
     keyboardSetting()
   }

--- a/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
@@ -14,7 +14,6 @@ class JudgmentReadyView: UIView {
   
   var closedButton: UIButton = {
     var configuration = UIButton.Configuration.plain()
-    configuration.background.backgroundColor = .red
     configuration.imagePadding = 0 // 기본 이미지 패딩 제거
     configuration.contentInsets = NSDirectionalEdgeInsets(top: 3, leading: 3, bottom: 3, trailing: 3)
     let button = UIButton(configuration: configuration)

--- a/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
@@ -15,10 +15,12 @@ class JudgmentReadyView: UIView {
   var closedButton: UIButton = {
     var configuration = UIButton.Configuration.plain()
     configuration.imagePadding = 0 // 기본 이미지 패딩 제거
-    configuration.contentInsets = NSDirectionalEdgeInsets(top: 3, leading: 3, bottom: 3, trailing: 3)
+    configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 0)
+    let symbolConfig = UIImage.SymbolConfiguration(pointSize: 15, weight: .regular)
+    let image = UIImage(systemName: "xmark", withConfiguration: symbolConfig)
     let button = UIButton(configuration: configuration)
     return button.set {
-      $0.setImage(.init(systemName: "xmark"), for: .normal)
+      $0.setImage(image, for: .normal)
       $0.frame = CGRect(x: 0, y: 0, width: 21, height: 21) // 터치 영역 확장
       $0.tintColor = .black
     }

--- a/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
@@ -11,10 +11,25 @@ class JudgmentReadyView: UIView {
   var blueBackgroundView = UIView().set {
     $0.backgroundColor = .akColor(.akBlue400)
   }
-  var paper = OpenedPaperView().set()
   
+  var closedButton: UIButton = {
+    var configuration = UIButton.Configuration.plain()
+    configuration.background.backgroundColor = .red
+    configuration.imagePadding = 0 // 기본 이미지 패딩 제거
+    configuration.contentInsets = NSDirectionalEdgeInsets(top: 3, leading: 3, bottom: 3, trailing: 3)
+    let button = UIButton(configuration: configuration)
+    return button.set {
+      $0.setImage(.init(systemName: "xmark"), for: .normal)
+      $0.frame = CGRect(x: 0, y: 0, width: 21, height: 21) // 터치 영역 확장
+      $0.tintColor = .black
+    }
+  }()
+  
+  var paper = OpenedPaperView().set()
   var paperBottomConstraint: NSLayoutConstraint?
   var paperCenterYConstraint: NSLayoutConstraint?
+  
+  var onActionTappedClosedButton: (() -> Void)?
   
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -52,7 +67,10 @@ class JudgmentReadyView: UIView {
   
   private func setupViews() {
     addSubview(blueBackgroundView)
+    addSubview(closedButton)
     addSubview(paper)
+    
+    closedButton.addTarget(self, action: #selector(tappedClosedButton), for: .touchUpInside)
   }
   
   private func setupConstraints() {
@@ -63,6 +81,9 @@ class JudgmentReadyView: UIView {
       blueBackgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
       blueBackgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
       blueBackgroundView.bottomAnchor.constraint(equalTo: bottomAnchor),
+      
+      closedButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+      closedButton.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 13),
       
       paper.leadingAnchor.constraint(equalTo: leadingAnchor, constant: paperPadding),
       paper.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -paperPadding)
@@ -90,6 +111,10 @@ class JudgmentReadyView: UIView {
     UIView.animate(withDuration: 0.3) {
       self.layoutIfNeeded()
     }
+  }
+  
+  @objc private func tappedClosedButton() {
+    onActionTappedClosedButton?()
   }
 }
 


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #86 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

### dismiss 버튼 영역 설정 
`xmark`의 이미지 (선)을 짚어야지만 버튼이 눌리는 것을 발견하고 아래와 같이 버튼 영역을 설정하였습니다 

<img width="212" alt="image" src="https://github.com/user-attachments/assets/f46d651d-2947-4f00-a532-eee2932da2b5">


```swift 
var closedButton: UIButton = {
    var configuration = UIButton.Configuration.plain()
    configuration.imagePadding = 0 // 기본 이미지 패딩 제거
    configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 0)
    let symbolConfig = UIImage.SymbolConfiguration(pointSize: 15, weight: .regular)
    let image = UIImage(systemName: "xmark", withConfiguration: symbolConfig)
    let button = UIButton(configuration: configuration)
    return button.set {
      $0.setImage(image, for: .normal)
      $0.frame = CGRect(x: 0, y: 0, width: 21, height: 21) // 터치 영역 확장
      $0.tintColor = .black
    }
  }()
```

단순히 `contentInsets`를 설정하면 색칠되는 영역은 변경되는 것 처럼 보이나, 실제 차이는 존재하지 않아 `frame`으로 그 크기를 잡아 주었습니다  
더 나아가 `frame` 만 잡으면 아무런 변화도 없기에 기존에 존재하던 이미지의 패딩을 제거하고 추가로 삽입, frame 고정을 진행하였습니다 

더 좋은 아이디어가 있다면 반영하여 수정하겠습니다!  


### 뒤로가기 버튼 

<img width="401" alt="image" src="https://github.com/user-attachments/assets/8bb34f38-a4eb-4177-b61b-64b4b2445d48">

따로 커스텀 하지 않고 타이틀을 없애고 틴트 컬러만 `GuideCoordinator` 내에서 지정해 주었습니다 

```swift 
func start() {
    let guideViewController = guideFactory.create(coordinator: self)
    guideViewController.navigationItem.backButtonTitle = ""
    navigationController.view.backgroundColor = .akColor(.akGray100) // ⭐️
    navigationController.navigationBar.tintColor = .black // ⭐️
    self.navigationController.viewControllers = [guideViewController]
  }
```
**guideViewController.navigationItem.backButtonTitle** 은 화면 전환을 주도하는 화면에서 결정되므로   
`guideViewController` 에 입혀 주었습니다 
(만약 `UserInfoViewController`에 적용하면 적용 X)  

추후 UserInfoCoordinator 구현체를 생성한다면 뒤로가기 이동 시 childCoordinator가 삭제되었다는 정보를 상위 Coordinator가 받을 수 있도록 네비게이션 제스쳐 인식을 달아주어야 합니다!   
하지만 현재는 하나의 코디네이터가 네비게이션 전환을 수행하므로 해당 작업이 필요하지 않았스빈다 


<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>   

![image](https://github.com/user-attachments/assets/4e4005c0-e51b-4555-aafc-281189723910)

