### PR TITLE
✨Feat: #87 GuideViewController 국가 선택 추가 및 기존 JudgmentView 국가 선택 기능 삭제, UseCase 리팩토링 

### DIFF
--- a/AKCOO.xcodeproj/project.pbxproj
+++ b/AKCOO.xcodeproj/project.pbxproj
@@ -653,8 +653,8 @@
 		F3EB763F2CDDDDAD0054D4E1 /* Scene */ = {
 			isa = PBXGroup;
 			children = (
-				F36F1A4B2CFCABAD00DD59F8 /* UserInfoScene */,
 				F36F1A2C2CFC73E800DD59F8 /* GuideScene */,
+				F36F1A4B2CFCABAD00DD59F8 /* UserInfoScene */,
 				F3ED92742CE38B8800CF5238 /* JudgmentScene */,
 				F3EB76422CDDDDD10054D4E1 /* Common */,
 			);

--- a/AKCOO.xcodeproj/project.pbxproj
+++ b/AKCOO.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		F36F1A5A2CFCB8A800DD59F8 /* UserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36F1A592CFCB8A800DD59F8 /* UserInfoView.swift */; };
 		F36F1A5C2CFCBCF600DD59F8 /* GuideUseCaseMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36F1A5B2CFCBCF600DD59F8 /* GuideUseCaseMock.swift */; };
 		F36F1A5E2CFCBD0A00DD59F8 /* UserInfoUseCaseMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36F1A5D2CFCBD0A00DD59F8 /* UserInfoUseCaseMock.swift */; };
+		F36F1A602CFD30D800DD59F8 /* CountrySelectorTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36F1A5F2CFD30D800DD59F8 /* CountrySelectorTitle.swift */; };
 		F379753A2CF0AA24006E8DC0 /* UILabel+PaperLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37975392CF0AA24006E8DC0 /* UILabel+PaperLabel.swift */; };
 		F3EB760D2CDD14B20054D4E1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F3EB760C2CDD14B20054D4E1 /* Assets.xcassets */; };
 		F3EB76102CDD14B20054D4E1 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = F3EB760F2CDD14B20054D4E1 /* Base */; };
@@ -248,6 +249,7 @@
 		F36F1A592CFCB8A800DD59F8 /* UserInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoView.swift; sourceTree = "<group>"; };
 		F36F1A5B2CFCBCF600DD59F8 /* GuideUseCaseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideUseCaseMock.swift; sourceTree = "<group>"; };
 		F36F1A5D2CFCBD0A00DD59F8 /* UserInfoUseCaseMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoUseCaseMock.swift; sourceTree = "<group>"; };
+		F36F1A5F2CFD30D800DD59F8 /* CountrySelectorTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorTitle.swift; sourceTree = "<group>"; };
 		F37975392CF0AA24006E8DC0 /* UILabel+PaperLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+PaperLabel.swift"; sourceTree = "<group>"; };
 		F3EB76002CDD14B00054D4E1 /* AKCOO.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AKCOO.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3EB760C2CDD14B20054D4E1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -510,6 +512,7 @@
 			isa = PBXGroup;
 			children = (
 				F36F1A532CFCADF400DD59F8 /* GuideView.swift */,
+				F36F1A5F2CFD30D800DD59F8 /* CountrySelectorTitle.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1456,6 +1459,7 @@
 				F3EB763B2CDDDC990054D4E1 /* AppDelegate.swift in Sources */,
 				F36F1A3C2CFCA4E100DD59F8 /* UserInfoFactory.swift in Sources */,
 				F3ED93252CEB2E2A00CF5238 /* BirdReactionCell.swift in Sources */,
+				F36F1A602CFD30D800DD59F8 /* CountrySelectorTitle.swift in Sources */,
 				F3ED932A2CEB30B200CF5238 /* Standard.swift in Sources */,
 				F3ED92D42CE72FE400CF5238 /* BirdModel.swift in Sources */,
 				F3EB768C2CDDECFF0054D4E1 /* UIFont+AKFont.swift in Sources */,

--- a/AKCOO/App/Coordinator/AppCoordinatorImp.swift
+++ b/AKCOO/App/Coordinator/AppCoordinatorImp.swift
@@ -20,10 +20,20 @@ final class AppCoordinatorImp: AppCoordinator {
   
   // App 폴더 내 최상위 Coordinator인 AppCoordinator이므로 직접 주입합니다
   func start() {
-    let judgmentUseCase = JudgmentUseCaseImp(judgmentRepository: JudgmentRepositoryMock(), recordRepository: RecordRepositoryImp())
+    let judgmentRepository = JudgmentRepositoryMock()
+    let recordRepository = RecordRepositoryImp()
     
-    let guideUseCase = GuideUseCaseMock()
-    let userInfoUseCase = UserInfoUseCaseMock()
+    let judgmentUseCase = JudgmentUseCaseImp(
+      judgmentRepository: judgmentRepository,
+      recordRepository: recordRepository
+    )
+    
+    let guideUseCase = GuideUseCaseImp(
+      judgmentRepository: judgmentRepository,
+      recordRepository: recordRepository
+    )
+    
+    let userInfoUseCase = UserInfoUseCaseImp()
     let guideFactory = GuideFactoryImp(useCase: guideUseCase)
     let userInfoFactory = UserInfoFactoryImp(useCase: userInfoUseCase)
     

--- a/AKCOO/DesignSystem/Font/AKFontType.swift
+++ b/AKCOO/DesignSystem/Font/AKFontType.swift
@@ -12,19 +12,21 @@ enum AKFontType {
   case gmarketMedium13
   case gmarketMedium14
   case gmarketMedium16
+  case gmarketMedium30
   
   case gmarketBold13
   case gmarketBold14
   case gmarketBold16
   case gmarketBold18
   case gmarketBold20
+  case gmarketBold30
   
   var customFont: String {
     switch self {
-    case .gmarketMedium12, .gmarketMedium13, .gmarketMedium14, .gmarketMedium16:
+    case .gmarketMedium12, .gmarketMedium13, .gmarketMedium14, .gmarketMedium16, .gmarketMedium30:
       return CustomFont.gmarketSansMedium.name
       
-    case .gmarketBold13, .gmarketBold14, .gmarketBold16, .gmarketBold18, .gmarketBold20:
+    case .gmarketBold13, .gmarketBold14, .gmarketBold16, .gmarketBold18, .gmarketBold20, .gmarketBold30:
       return CustomFont.gmarketSansBold.name
     }
   }
@@ -35,12 +37,14 @@ enum AKFontType {
     case .gmarketMedium13: 13
     case .gmarketMedium14: 14
     case .gmarketMedium16: 16
+    case .gmarketMedium30: 30
       
     case .gmarketBold13: 13
     case .gmarketBold14: 14
     case .gmarketBold16: 16
     case .gmarketBold18: 18
     case .gmarketBold20: 20
+    case .gmarketBold30: 30
     }
   }
 }

--- a/AKCOO/Domain/UseCase/GuideUseCaseImp.swift
+++ b/AKCOO/Domain/UseCase/GuideUseCaseImp.swift
@@ -7,16 +7,70 @@
 
 import Foundation
 
-struct GuideUseCaseImp: GuideUseCase {
-  func getCountryNames() -> Result<[String], any Error> {
-    return .failure(NetworkError())
+class GuideUseCaseImp: GuideUseCase {
+  private let judgmentRepository: JudgmentRepository
+  private let recordRepository: RecordRepository
+  
+  private var countriesDetails: [CountryDetail]?
+  private var selectedCountryDetail: CountryDetail?
+  
+  init(
+    judgmentRepository: JudgmentRepository,
+    recordRepository: RecordRepository
+  ) {
+    self.judgmentRepository = judgmentRepository
+    self.recordRepository = recordRepository
   }
   
-  func getCountryDetail() -> Result<CountryDetail, any Error> {
-    return .failure(NetworkError())
+  func getGuideInfo() async -> Result<([String], CountryDetail), Error> {
+    
+    let tmpCountriesDetails: [CountryDetail]
+    let tmpSelectedCountryDetail: CountryDetail
+    let countriesName: [String]
+    
+    if let countriesDetails, let selectedCountryDetail {
+      tmpCountriesDetails = countriesDetails
+      tmpSelectedCountryDetail = selectedCountryDetail
+    } else {
+      let allCountriesDetailsResult = await judgmentRepository.fetchAllCountriesDetails()
+      switch allCountriesDetailsResult {
+      case .success(let countriesDetails):
+        self.countriesDetails = countriesDetails
+        tmpCountriesDetails = countriesDetails
+      case .failure(let error): return .failure(error)
+      }
+      
+      let selectedCountryResult = recordRepository.fetchSelectedCountry()
+      switch selectedCountryResult {
+      case .success(let selectedCountryName):
+        if let selectedCountryName, let selectedCountryDetail = tmpCountriesDetails.filter({ $0.name == selectedCountryName }).first {
+          tmpSelectedCountryDetail = selectedCountryDetail
+        } else if let firstDetails = tmpCountriesDetails.first {
+          tmpSelectedCountryDetail = firstDetails
+        } else {
+          tmpSelectedCountryDetail = .init(country: .init(name: "", currency: .init(unitTitle: "", unit: 0)), items: [])
+          print("CountriesDetails이 없습니다")
+        }
+      case .failure(let error): return .failure(error)
+      }
+    }
+    
+    self.countriesDetails = tmpCountriesDetails
+    self.selectedCountryDetail = tmpSelectedCountryDetail
+    
+    countriesName = tmpCountriesDetails.map { $0.name }
+    
+    return .success((countriesName, tmpSelectedCountryDetail))
   }
   
-  func getNewCountryDetail(newCountryName selectedCountryName: String) -> Result<CountryDetail, any Error> {
-    return .failure(NetworkError())
+  func getNewGuideInfo(newCountryName selectedCountryName: String) async -> Result<([String], CountryDetail), Error> {
+    guard
+      let countriesDetails,
+      let newSelectedCountryDetail = countriesDetails.filter({ $0.name == selectedCountryName }).first else { return .failure(NetworkError()) }
+
+    _ = recordRepository.saveSelectedCountry(selectedCountryName)
+    selectedCountryDetail = newSelectedCountryDetail
+    
+    return await getGuideInfo()
   }
 }

--- a/AKCOO/Domain/UseCase/Interface/Mock/GuideUseCaseMock.swift
+++ b/AKCOO/Domain/UseCase/Interface/Mock/GuideUseCaseMock.swift
@@ -8,6 +8,19 @@
 import Foundation
 
 struct GuideUseCaseMock: GuideUseCase {
+  func getGuideInfo() async -> Result<([String], CountryDetail), any Error> {
+    .success(
+      (
+        ["스위스", "베트남"],
+        .init(country: .init(name: "베트남", currency: .init(unitTitle: "동", unit: 0.059)), items: [])
+      )
+    )
+  }
+  
+  func getNewGuideInfo(newCountryName selectedCountryName: String) async -> Result<([String], CountryDetail), any Error> {
+    return await getGuideInfo()
+  }
+  
   func getCountryNames() -> Result<[String], any Error> {
     return .success(["베트남", "스위스"])
   }

--- a/AKCOO/Domain/UseCase/Interface/Mock/JudgmentUseCaseMock.swift
+++ b/AKCOO/Domain/UseCase/Interface/Mock/JudgmentUseCaseMock.swift
@@ -51,34 +51,13 @@ class JudgmentUseCaseMock: JudgmentUseCase {
     }
   }
   
-  func getPaperModel() -> Result<PaperModel, Error> {
+  func getPaperModel(selectedCountryDetail: CountryDetail) -> Result<PaperModel, Error> {
     // 선택된 국가를 RecordRepository에서 가져오기
     guard let countriesDetails else { return .failure(NetworkError()) }
-    guard let selectedCountryDetail else { return .failure(NetworkError()) }
 
-    let countryProfiles = getCountryProfiles(to: countriesDetails)
-    let countryNames = countryProfiles.map { $0.name }
-    let selectedCategories = selectedCountryDetail.categories
-    let paperModel = PaperModel(
-      selectedCountryProfile: CountryProfile.init(name: selectedCountryDetail.name, currency: selectedCountryDetail.currency), 
-      countries: countryNames,
-      categories: selectedCategories
-    )
-    
-    return .success(paperModel)
-  }
-  
-  func getNewPaperModel(newCountryName selectedCountryName: String) -> Result<PaperModel, any Error> {
-    // 선택된 국가를 RecordRepository에서 가져오기
-    guard let countriesDetails else { return .failure(NetworkError()) }
-    guard let selectedCountryDetail else { return .failure(NetworkError()) }
-    
-    let countryProfiles = getCountryProfiles(to: countriesDetails)
-    let countryNames = countryProfiles.map { $0.name }
     let selectedCategories = selectedCountryDetail.categories
     let paperModel = PaperModel(
       selectedCountryProfile: CountryProfile.init(name: selectedCountryDetail.name, currency: selectedCountryDetail.currency),
-      countries: countryNames,
       categories: selectedCategories
     )
     
@@ -89,8 +68,7 @@ class JudgmentUseCaseMock: JudgmentUseCase {
     return false 
   }
   
-  func getBirdsJudgment(userQuestion: UserQuestion) -> Result<[BirdModel], Error> {
-    guard let selectedCountryDetail else { return .failure(NetworkError()) }
+  func getBirdsJudgment(selectedCountryDetail: CountryDetail, userQuestion: UserQuestion) -> Result<[BirdModel], Error> {
     guard let localCountryDetail else { return .failure(NetworkError()) }
     let previousResult = recordRepository.fetchPreviousDaySpending(country: userQuestion.country.name, category: userQuestion.category)
     guard case .success(let previousRecord) = previousResult else { return .failure(NetworkError()) }

--- a/AKCOO/Domain/UseCase/Interface/UseCase/GuideUseCase.swift
+++ b/AKCOO/Domain/UseCase/Interface/UseCase/GuideUseCase.swift
@@ -8,10 +8,9 @@
 import Foundation
 
 protocol GuideUseCase {
-  /// 최초 실행 시 국가 이름 리스트 받아오는 메서드
-  func getCountryNames() -> Result<[String], Error>
-  /// 선택된 국가 정보를 불러오는 메서드 (없다면 첫 나라 정보로 자동 배정)
-  func getCountryDetail() -> Result<CountryDetail, Error>
+  /// 최초 실행 시 국가 이름 리스트와 선택된 국가 정보를 불러오는 메서드
+  /// (없다면 첫 나라 정보로 자동 배정)
+  func getGuideInfo() async -> Result<([String], CountryDetail), Error>
   /// 나라 변경 후 필요한 정보를 받는 메서드
-  func getNewCountryDetail(newCountryName selectedCountryName: String) -> Result<CountryDetail, Error>
+  func getNewGuideInfo(newCountryName selectedCountryName: String) async -> Result<([String], CountryDetail), Error>
 }

--- a/AKCOO/Domain/UseCase/Interface/UseCase/JudgmentUseCase.swift
+++ b/AKCOO/Domain/UseCase/Interface/UseCase/JudgmentUseCase.swift
@@ -11,11 +11,9 @@ protocol JudgmentUseCase {
   /// 판단을 저장하는 메서드
   func save(record: UserRecord) -> Result<VoidResponse, Error>
   /// 화면에 필요한 정보를 반환하는 메서드
-  func getPaperModel() -> Result<PaperModel, Error>
+  func getPaperModel(selectedCountryDetail: CountryDetail) -> Result<PaperModel, Error>
   /// 직전 소비가 존재하는 지 확인하는 메서드
   func isPreviousRecordExists(for country: String, category: String) -> Bool
-  /// 나라 변경 후 필요한 정보를 반환하는 메서드
-  func getNewPaperModel(newCountryName selectedCountryName: String) -> Result<PaperModel, Error>
   /// 특정 국가, 카테고리, 서브 카테고리에 대한 판정을 요청하는 메서드
-  func getBirdsJudgment(userQuestion: UserQuestion) -> Result<[BirdModel], Error>
+  func getBirdsJudgment(selectedCountryDetail: CountryDetail, userQuestion: UserQuestion) async -> Result<[BirdModel], Error>
 }

--- a/AKCOO/Domain/ViewModel/Paper/PaperModel.swift
+++ b/AKCOO/Domain/ViewModel/Paper/PaperModel.swift
@@ -10,6 +10,5 @@ import Foundation
 /// 재판요청서를 보이기 위해 화면에 필요한 값
 struct PaperModel {
   var selectedCountryProfile: CountryProfile // 선택된 국가
-  var countries: [String]                    // 국가 리스트
   var categories: [String]                   // 선택된 국가 카테고리 정보
 }

--- a/AKCOO/Scene/GuideScene/Controller/GuideViewController.swift
+++ b/AKCOO/Scene/GuideScene/Controller/GuideViewController.swift
@@ -16,9 +16,13 @@ class GuideViewController: UIViewController {
     return view as? GuideView
   }
   
+  private var selectedCountry: String = ""
+  
   init(guideUseCase: GuideUseCase) {
     self.guideUseCase = guideUseCase
     super.init(nibName: nil, bundle: nil)
+    
+    selectedCountry = "스위스" // CountryDetail 받아올 때 초기화
   }
   
   required init?(coder: NSCoder) {
@@ -32,7 +36,13 @@ class GuideViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
+    configure()
     onAction()
+  }
+  
+  private func configure() {
+    guard case let .success(countries) = guideUseCase.getCountryNames() else { return } // 예외처리
+    guideView.configure(countries: countries, selectedCountry: selectedCountry)
   }
   
   private func onAction() {

--- a/AKCOO/Scene/GuideScene/Controller/GuideViewController.swift
+++ b/AKCOO/Scene/GuideScene/Controller/GuideViewController.swift
@@ -55,6 +55,12 @@ class GuideViewController: UIViewController {
       guard let self else { return }
       self.coordinator?.startJudgmentReady(presenting: self)
     }
+    
+    guideView.countrySelectorTitle.onActionChangeCountry = { [weak self] newCountry in
+      guard let self else { return }
+      _ = self.guideUseCase.getNewCountryDetail(newCountryName: newCountry)
+      // selectedCountry 도 변경
+    }
   }
 }
 

--- a/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinator.swift
+++ b/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinator.swift
@@ -8,6 +8,6 @@
 import UIKit
 
 protocol GuideCoordinator: Coordinator {
-  func startJudgmentReady(presenting: UIViewController)
+  func startJudgmentReady(presenting: UIViewController, selectedCountryDetail: CountryDetail)
   func startUserInfo()
 }

--- a/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinatorImp.swift
+++ b/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinatorImp.swift
@@ -31,6 +31,7 @@ class GuideCoordinatorImp: GuideCoordinator, UserInfoCoordinator {
   
   func start() {
     let guideViewController = guideFactory.create(coordinator: self)
+    guideViewController.navigationItem.backButtonTitle = ""
     navigationController.view.backgroundColor = .akColor(.akGray100)
     self.navigationController.viewControllers = [guideViewController]
   }
@@ -44,6 +45,7 @@ class GuideCoordinatorImp: GuideCoordinator, UserInfoCoordinator {
   func startUserInfo() {
     let userViewController = userInfoFactory.create(coordinator: self)
     userViewController.view.backgroundColor = .akColor(.akGray100)
+    self.navigationController.navigationBar.tintColor = .black
     self.navigationController.pushViewController(userViewController, animated: true)
   }
   

--- a/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinatorImp.swift
+++ b/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinatorImp.swift
@@ -32,6 +32,7 @@ class GuideCoordinatorImp: GuideCoordinator, UserInfoCoordinator {
   func start() {
     let guideViewController = guideFactory.create(coordinator: self)
     guideViewController.navigationItem.backButtonTitle = ""
+    navigationController.navigationBar.tintColor = .black
     navigationController.view.backgroundColor = .akColor(.akGray100)
     self.navigationController.viewControllers = [guideViewController]
   }
@@ -45,7 +46,6 @@ class GuideCoordinatorImp: GuideCoordinator, UserInfoCoordinator {
   func startUserInfo() {
     let userViewController = userInfoFactory.create(coordinator: self)
     userViewController.view.backgroundColor = .akColor(.akGray100)
-    self.navigationController.navigationBar.tintColor = .black
     self.navigationController.pushViewController(userViewController, animated: true)
   }
   

--- a/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinatorImp.swift
+++ b/AKCOO/Scene/GuideScene/Coordinator/GuideCoordinatorImp.swift
@@ -37,8 +37,9 @@ class GuideCoordinatorImp: GuideCoordinator, UserInfoCoordinator {
     self.navigationController.viewControllers = [guideViewController]
   }
   
-  func startJudgmentReady(presenting: UIViewController) {
+  func startJudgmentReady(presenting: UIViewController, selectedCountryDetail: CountryDetail) {
     judgmentCoordinator.finishDelegate = self
+    judgmentCoordinator.selectedCountryDetail = selectedCountryDetail
     childCoordinators.append(judgmentCoordinator)
     judgmentCoordinator.start()
   }

--- a/AKCOO/Scene/GuideScene/View/CountrySelectorTitle.swift
+++ b/AKCOO/Scene/GuideScene/View/CountrySelectorTitle.swift
@@ -1,0 +1,134 @@
+//
+//  CountrySelectorTitle.swift
+//  AKCOO
+//
+//  Created by 박혜운 on 12/2/24.
+//
+
+import UIKit
+
+class CountrySelectorTitle: UIView {
+  
+  // MARK: - Views
+  let contentStack = UIStackView().set {
+    $0.axis = .vertical
+    $0.alignment = .leading
+    $0.distribution = .fill
+    $0.distribution = .equalSpacing
+  }
+  
+  lazy var explanationLabel = UILabel().set {
+    $0.text = "여행중이신가요?"
+    $0.font = .akFont(.gmarketMedium30)
+  }
+  
+  let countryButton = {
+    var configuration = UIButton.Configuration.filled()
+    configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+    configuration.imagePadding = 5
+    configuration.baseForegroundColor = .black
+    configuration.baseBackgroundColor = .clear
+    configuration.imagePlacement = .trailing
+    
+    let button = UIButton(configuration: configuration)
+    
+    return button.set {
+      $0.setImage(
+        UIImage(systemName: "chevron.down")?
+          .withConfiguration(UIImage.SymbolConfiguration(pointSize: 22)),
+        for: .normal
+      )
+    }
+  }()
+  
+  private var selectedCountry: String?
+  
+  // MARK: - OnAction
+  var onActionChangeCountry: ((String) -> Void)?
+  
+  // MARK: - Initializers
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupViews()
+    setupConstraints()
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    setupViews()
+    setupConstraints()
+  }
+  
+  // MARK: - Setup Methods
+  private func setupViews() {
+    addSubview(contentStack)
+    
+    contentStack.addArrangedSubview(countryButton)
+    contentStack.addArrangedSubview(explanationLabel)
+  }
+  
+  private func setupConstraints() {
+    NSLayoutConstraint.activate([
+      contentStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+      contentStack.trailingAnchor.constraint(equalTo: trailingAnchor),
+      contentStack.topAnchor.constraint(equalTo: topAnchor),
+      contentStack.bottomAnchor.constraint(equalTo: bottomAnchor)
+    ])
+  }
+  
+  // MARK: - Configuration
+  func configure(countries: [String], selectedCountry: String) {
+    self.selectedCountry = selectedCountry
+    
+    configureButton(selectedCountry: selectedCountry)
+    
+    setupMenu(countries)
+  }
+  
+  private func setupMenu(_ countries: [String]) {
+    let menu = UIMenu(
+      title: "",
+      children: countries.map { country in
+        UIAction(
+          title: country,
+          image: country == self.selectedCountry ? UIImage(systemName: "checkmark") : nil,
+          handler: { [weak self] _ in
+            guard let self else { return }
+            
+            self.configureButton(selectedCountry: country)
+            
+            self.selectedCountry = country
+            self.setupMenu(countries)
+            self.onActionChangeCountry?(country)
+          }
+        )
+      }
+    )
+    
+    countryButton.menu = menu
+    countryButton.showsMenuAsPrimaryAction = true
+  }
+  
+  private func configureButton(selectedCountry: String) {
+    let attributedString = NSAttributedString(
+      string: selectedCountry,
+      attributes: [
+        .underlineStyle: NSUnderlineStyle.single.rawValue,
+        .font: UIFont.akFont(.gmarketBold30) as Any,
+        .baselineOffset: 8
+      ]
+    )
+    
+    countryButton.setAttributedTitle(attributedString, for: .normal)
+  }
+}
+
+#Preview {
+  let countrySelector = CountrySelectorTitle()
+  countrySelector.configure(
+    countries: ["베트남", "스위스"],
+    selectedCountry: "베트남"
+  )
+  
+  return countrySelector
+}

--- a/AKCOO/Scene/GuideScene/View/GuideView.swift
+++ b/AKCOO/Scene/GuideScene/View/GuideView.swift
@@ -8,10 +8,6 @@
 import UIKit
 
 class GuideView: UIView {
-
-  let titleLabel = UILabel().set {
-    $0.text = "GuideView"
-  }
   
   let userInfoButton = UIButton().set {
     $0.setTitle("UserInfo로 이동", for: .normal)
@@ -24,6 +20,8 @@ class GuideView: UIView {
     $0.tintColor = .red
     $0.backgroundColor = .blue
   }
+  
+  let countrySelectorTitle = CountrySelectorTitle().set()
   
   var onActionUserInfoTapped: (() -> Void)? // 임시 생성
   var onActionJudgmentTapped: (() -> Void)? // 임시 생성
@@ -41,7 +39,7 @@ class GuideView: UIView {
   }
   
   private func setupViews() {
-    self.addSubview(titleLabel)
+    self.addSubview(countrySelectorTitle)
     self.addSubview(userInfoButton)
     self.addSubview(judgmentButton)
     
@@ -52,8 +50,8 @@ class GuideView: UIView {
   
   private func setupConstraints() {
     NSLayoutConstraint.activate([
-      titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-      titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+      countrySelectorTitle.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 33),
+      countrySelectorTitle.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 68),
       
       userInfoButton.centerXAnchor.constraint(equalTo: centerXAnchor),
       userInfoButton.centerYAnchor.constraint(equalTo: centerYAnchor, constant: 50),
@@ -63,17 +61,25 @@ class GuideView: UIView {
     ])
   }
   
+  func configure(countries: [String], selectedCountry: String) {
+    countrySelectorTitle.configure(countries: countries, selectedCountry: selectedCountry)
+  }
+  
   @objc func tappedUserInfoBird() {
-    print("UserInfoBird")
     onActionUserInfoTapped?()
   }
   
   @objc func tappedStartJudgment() {
-    print("Judgment")
     onActionJudgmentTapped?()
   }
 }
 
 #Preview {
-  GuideView()
+  let view = GuideView()
+  view.configure(
+    countries: ["베트남", "스위스"],
+    selectedCountry: "스위스"
+  )
+  
+  return view
 }

--- a/AKCOO/Scene/JudgmentScene/Controller/Factory/JudgementReadyFactory.swift
+++ b/AKCOO/Scene/JudgmentScene/Controller/Factory/JudgementReadyFactory.swift
@@ -8,5 +8,5 @@
 import UIKit
 
 protocol JudgmentReadyFactory {
-  func create(coordinator: JudgmentCoordinator) -> UIViewController
+  func create(coordinator: JudgmentCoordinator, selectedCountryDetail: CountryDetail) -> UIViewController
 }

--- a/AKCOO/Scene/JudgmentScene/Controller/Factory/JudgementReadyFactoryImp.swift
+++ b/AKCOO/Scene/JudgmentScene/Controller/Factory/JudgementReadyFactoryImp.swift
@@ -10,8 +10,8 @@ import UIKit
 struct JudgmentReadyFactoryImp: JudgmentReadyFactory {
   let useCase: JudgmentUseCase
   
-  func create(coordinator: JudgmentCoordinator) -> UIViewController {
-    let readyController = JudgmentReadyViewController(judgmentUseCase: useCase)
+  func create(coordinator: JudgmentCoordinator, selectedCountryDetail: CountryDetail) -> UIViewController {
+    let readyController = JudgmentReadyViewController(judgmentUseCase: useCase, selectedCountryDetail: selectedCountryDetail)
     readyController.coordinator = coordinator
     return readyController
   }

--- a/AKCOO/Scene/JudgmentScene/Controller/Factory/JudgmentCompletedFactory.swift
+++ b/AKCOO/Scene/JudgmentScene/Controller/Factory/JudgmentCompletedFactory.swift
@@ -8,6 +8,11 @@
 import UIKit
 
 protocol JudgmentCompletedFactory {
-  func create(coordinator: JudgmentCoordinator, delegate: JudgmentCompletedViewControllerDelegate, userQuestion: UserQuestion) -> UIViewController 
+  func create(
+    coordinator: JudgmentCoordinator,
+    delegate: any JudgmentCompletedViewControllerDelegate,
+    selectedCountryDetail: CountryDetail,
+    userQuestion: UserQuestion
+  ) -> UIViewController
   func dismisser(judgmentCompletedViewController viewController: UIViewController)
 }

--- a/AKCOO/Scene/JudgmentScene/Controller/Factory/JudgmentCompletedFactoryImp.swift
+++ b/AKCOO/Scene/JudgmentScene/Controller/Factory/JudgmentCompletedFactoryImp.swift
@@ -10,8 +10,17 @@ import UIKit
 struct JudgmentCompletedFactoryImp: JudgmentCompletedFactory {
   let useCase: JudgmentUseCase
   
-  func create(coordinator: JudgmentCoordinator, delegate: any JudgmentCompletedViewControllerDelegate, userQuestion: UserQuestion) -> UIViewController {
-    let judgmentCompletedViewController = JudgmentCompletedViewController(judgmentUseCase: useCase, userQuestion: userQuestion)
+  func create(
+    coordinator: JudgmentCoordinator,
+    delegate: any JudgmentCompletedViewControllerDelegate,
+    selectedCountryDetail: CountryDetail,
+    userQuestion: UserQuestion
+  ) -> UIViewController {
+    let judgmentCompletedViewController = JudgmentCompletedViewController(
+      judgmentUseCase: useCase,
+      selectedCountryDetail: selectedCountryDetail,
+      userQuestion: userQuestion
+    )
     judgmentCompletedViewController.coordinator = coordinator
     judgmentCompletedViewController.delegate = delegate
     return judgmentCompletedViewController

--- a/AKCOO/Scene/JudgmentScene/Controller/JudgmentEditViewController.swift
+++ b/AKCOO/Scene/JudgmentScene/Controller/JudgmentEditViewController.swift
@@ -69,17 +69,6 @@ class JudgmentEditViewController: UIViewController {
   
   private func onAction() {
     judgmentEditView.paper.onActionChange(
-      country: { [weak self] changedCountry in
-        guard let self else { return }
-        // PaperModel 변경
-        switch self.judgmentUseCase.getNewPaperModel(newCountryName: changedCountry) {
-        case .success(let newPaperModel):
-          self.paperModel = newPaperModel
-          self.setupUI()
-        case .failure: return
-            // TODO: - 예외처리
-        }
-      },
       category: { [weak self] changedCategory in
         guard let self else { return }
         selectedCategory = changedCategory ?? ""

--- a/AKCOO/Scene/JudgmentScene/Controller/JudgmentReadyViewController.swift
+++ b/AKCOO/Scene/JudgmentScene/Controller/JudgmentReadyViewController.swift
@@ -48,6 +48,10 @@ class JudgmentReadyViewController: UIViewController {
   }
   
   private func setupViews() {
+    judgmentReadyView.onActionTappedClosedButton = { [weak self] in
+      guard let self else { return }
+      coordinator?.completedJudgment(judgmentViewController: self)
+    }
     judgmentReadyView.paper.readyButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tappedReadyButton)))
     keyboardSetting()
   }

--- a/AKCOO/Scene/JudgmentScene/Coordinator/JudgmentCoordinator.swift
+++ b/AKCOO/Scene/JudgmentScene/Coordinator/JudgmentCoordinator.swift
@@ -8,9 +8,15 @@
 import UIKit
 
 protocol JudgmentCoordinator: Coordinator {
-  func startJudgment(presenting: JudgmentCompletedViewControllerDelegate, userQuestion: UserQuestion)
+  func startJudgment(
+    presenting: JudgmentCompletedViewControllerDelegate,
+    selectedCountryDetail: CountryDetail,
+    userQuestion: UserQuestion
+  )
   func completedJudgment(judgmentViewController: UIViewController)
   func startEditPaper(presenting: JudgmentEditViewControllerDelegate, paperModel: PaperModel, selectedCategory: String, userAmount: String)
   func completedEditPaper(editViewController: UIViewController)
   func dismiss()
+  
+  var selectedCountryDetail: CountryDetail? { get set }
 }

--- a/AKCOO/Scene/JudgmentScene/Coordinator/JudgmentCoordinatorImp.swift
+++ b/AKCOO/Scene/JudgmentScene/Coordinator/JudgmentCoordinatorImp.swift
@@ -20,6 +20,8 @@ class JudgmentCoordinatorImp: JudgmentCoordinator {
   private let judgmentTransitionaler = JudgmentTransitionaler()
   private let editTransitionaler = EditTransitionaler()
   
+  var selectedCountryDetail: CountryDetail?
+  
   required init(
     _ navigationController: UINavigationController,
     judgmentReadyNewfactory: any JudgmentReadyFactory,
@@ -33,13 +35,23 @@ class JudgmentCoordinatorImp: JudgmentCoordinator {
   }
   
   func start() {
-    let newViewController = judgmentReadyFactory.create(coordinator: self)
+    guard let selectedCountryDetail else { return } // 예외처리
+    let newViewController = judgmentReadyFactory.create(coordinator: self, selectedCountryDetail: selectedCountryDetail)
     newViewController.modalPresentationStyle = .fullScreen
     self.navigationController.present(newViewController, animated: true)
   }
   
-  func startJudgment(presenting: JudgmentCompletedViewControllerDelegate, userQuestion: UserQuestion) { // 데이터 받아와서 진행
-    let judgmentCompletedViewController = judgmentCompletedFactory.create(coordinator: self, delegate: presenting, userQuestion: userQuestion)
+  func startJudgment(
+    presenting: JudgmentCompletedViewControllerDelegate,
+    selectedCountryDetail: CountryDetail,
+    userQuestion: UserQuestion
+  ) { // 데이터 받아와서 진행
+    let judgmentCompletedViewController = judgmentCompletedFactory.create(
+      coordinator: self,
+      delegate: presenting,
+      selectedCountryDetail: selectedCountryDetail,
+      userQuestion: userQuestion
+    )
     judgmentCompletedViewController.modalPresentationStyle = .overFullScreen
     judgmentCompletedViewController.transitioningDelegate = self.judgmentTransitionaler
     judgmentCompletedViewController.view.backgroundColor = .akColor(.akBlue400)

--- a/AKCOO/Scene/JudgmentScene/Coordinator/Presenter/EditTransition.swift
+++ b/AKCOO/Scene/JudgmentScene/Coordinator/Presenter/EditTransition.swift
@@ -59,7 +59,7 @@ class EditTransition: NSObject, UIViewControllerAnimatedTransitioning {
           (from: textField, to: judgmentView.paper.amountLabel, action: .move),
           (from: judgmentEditView.paper.amountTextField.unitLabel, to: judgmentView.paper.unitTitleLabel, action: .move),
           (from: judgmentEditView.paper.amountTextField.separatorLine, to: judgmentView.paper.separatorLine, action: .move),
-          (from: judgmentEditView.paper.countrySelector.countryButton.titleLabel ?? .paperLabel(with: ""), to: judgmentView.paper.countryLabel, action: .move),
+          (from: judgmentEditView.paper.countrySelector.countryLabel, to: judgmentView.paper.countryLabel, action: .move),
           (from: judgmentEditView.paper.categorySelector.selectedButton ?? .init(), to: judgmentView.paper.category, action: .move),
           (from: judgmentView.paper.reInputTextView, to: judgmentView.paper.reInputTextView, action: .appear),
           (from: judgmentView.paperTitleLabel, to: judgmentView.paperTitleLabel, action: .appear),

--- a/AKCOO/Scene/JudgmentScene/Coordinator/Presenter/JudgmentTransition.swift
+++ b/AKCOO/Scene/JudgmentScene/Coordinator/Presenter/JudgmentTransition.swift
@@ -57,7 +57,7 @@ class JudgmentTransition: NSObject, UIViewControllerAnimatedTransitioning {
           (from: textField, to: judgmentView.paper.amountLabel, action: .move),
           (from: judgmentReadyView.paper.amountTextField.unitLabel, to: judgmentView.paper.unitTitleLabel, action: .move),
           (from: judgmentReadyView.paper.amountTextField.separatorLine, to: judgmentView.paper.separatorLine, action: .move),
-          (from: judgmentReadyView.paper.countrySelector.countryButton.titleLabel ?? .paperLabel(with: ""), to: judgmentView.paper.countryLabel, action: .move),
+          (from: judgmentReadyView.paper.countrySelector.countryLabel, to: judgmentView.paper.countryLabel, action: .move),
           (from: judgmentReadyView.paper.categorySelector.selectedButton ?? .init(), to: judgmentView.paper.category, action: .move),
           (from: judgmentView.paper.reInputTextView, to: judgmentView.paper.reInputTextView, action: .appear),
           (from: judgmentView.paperTitleLabel, to: judgmentView.paperTitleLabel, action: .appear),

--- a/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentEditView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentEditView.swift
@@ -93,7 +93,6 @@ class JudgmentEditView: UIView {
           unitTitle: "동", unit: 0.05539
         )
       ),
-      countries: ["베트남", "스위스"],
       categories: ["가", "나", "다"]
     ),
     selectedCategory: "다",

--- a/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
@@ -121,15 +121,15 @@ class JudgmentReadyView: UIView {
 
 #Preview {
   let readyView = JudgmentReadyView()
-  readyView.configure(
+  readyView
+    .configure(
     paperModel: .init(
       selectedCountryProfile: .init(
         name: "베트남",
         currency: .init(
           unitTitle: "동", unit: 0.05539
         )
-      ), 
-      countries: ["베트남", "스위스"],
+      ),
       categories: ["가", "나", "다"]
     ), 
     previousRecordExists: false

--- a/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
@@ -14,7 +14,6 @@ class JudgmentReadyView: UIView {
   
   var closedButton: UIButton = {
     var configuration = UIButton.Configuration.plain()
-    configuration.background.backgroundColor = .red
     configuration.imagePadding = 0 // 기본 이미지 패딩 제거
     configuration.contentInsets = NSDirectionalEdgeInsets(top: 3, leading: 3, bottom: 3, trailing: 3)
     let button = UIButton(configuration: configuration)

--- a/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
@@ -15,10 +15,12 @@ class JudgmentReadyView: UIView {
   var closedButton: UIButton = {
     var configuration = UIButton.Configuration.plain()
     configuration.imagePadding = 0 // 기본 이미지 패딩 제거
-    configuration.contentInsets = NSDirectionalEdgeInsets(top: 3, leading: 3, bottom: 3, trailing: 3)
+    configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 0)
+    let symbolConfig = UIImage.SymbolConfiguration(pointSize: 15, weight: .regular)
+    let image = UIImage(systemName: "xmark", withConfiguration: symbolConfig)
     let button = UIButton(configuration: configuration)
     return button.set {
-      $0.setImage(.init(systemName: "xmark"), for: .normal)
+      $0.setImage(image, for: .normal)
       $0.frame = CGRect(x: 0, y: 0, width: 21, height: 21) // 터치 영역 확장
       $0.tintColor = .black
     }

--- a/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentReadyView.swift
@@ -11,10 +11,25 @@ class JudgmentReadyView: UIView {
   var blueBackgroundView = UIView().set {
     $0.backgroundColor = .akColor(.akBlue400)
   }
-  var paper = OpenedPaperView().set()
   
+  var closedButton: UIButton = {
+    var configuration = UIButton.Configuration.plain()
+    configuration.background.backgroundColor = .red
+    configuration.imagePadding = 0 // 기본 이미지 패딩 제거
+    configuration.contentInsets = NSDirectionalEdgeInsets(top: 3, leading: 3, bottom: 3, trailing: 3)
+    let button = UIButton(configuration: configuration)
+    return button.set {
+      $0.setImage(.init(systemName: "xmark"), for: .normal)
+      $0.frame = CGRect(x: 0, y: 0, width: 21, height: 21) // 터치 영역 확장
+      $0.tintColor = .black
+    }
+  }()
+  
+  var paper = OpenedPaperView().set()
   var paperBottomConstraint: NSLayoutConstraint?
   var paperCenterYConstraint: NSLayoutConstraint?
+  
+  var onActionTappedClosedButton: (() -> Void)?
   
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -52,7 +67,10 @@ class JudgmentReadyView: UIView {
   
   private func setupViews() {
     addSubview(blueBackgroundView)
+    addSubview(closedButton)
     addSubview(paper)
+    
+    closedButton.addTarget(self, action: #selector(tappedClosedButton), for: .touchUpInside)
   }
   
   private func setupConstraints() {
@@ -63,6 +81,9 @@ class JudgmentReadyView: UIView {
       blueBackgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
       blueBackgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
       blueBackgroundView.bottomAnchor.constraint(equalTo: bottomAnchor),
+      
+      closedButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+      closedButton.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 13),
       
       paper.leadingAnchor.constraint(equalTo: leadingAnchor, constant: paperPadding),
       paper.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -paperPadding)
@@ -90,6 +111,10 @@ class JudgmentReadyView: UIView {
     UIView.animate(withDuration: 0.3) {
       self.layoutIfNeeded()
     }
+  }
+  
+  @objc private func tappedClosedButton() {
+    onActionTappedClosedButton?()
   }
 }
 

--- a/AKCOO/Scene/JudgmentScene/View/Paper/Components/CountrySelector.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Paper/Components/CountrySelector.swift
@@ -19,24 +19,29 @@ class CountrySelector: UIView {
   
   lazy var titleLabel: UILabel = .paperLabel(with: "국가").set()
   
-  let countryButton = {
-    var configuration = UIButton.Configuration.filled()
-    configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
-    configuration.imagePadding = 5
-    configuration.baseForegroundColor = .black
-    configuration.baseBackgroundColor = .clear
-    
-    let button = UIButton(configuration: configuration)
-    return button.set {
-      $0.setImage(UIImage(systemName: "chevron.down")?.withConfiguration(UIImage.SymbolConfiguration(pointSize: 10)), for: .normal)
-      $0.semanticContentAttribute = .forceRightToLeft
-    }
-  }()
+  let countryLabel = UILabel().set {
+    $0.text = "베트남"
+    $0.font = .akFont(.gmarketBold16)
+  }
   
-  private var selectedCountry: String?
+//  let countryLabel = {
+//    var configuration = UIButton.Configuration.filled()
+//    configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+//    configuration.imagePadding = 5
+//    configuration.baseForegroundColor = .black
+//    configuration.baseBackgroundColor = .clear
+//    
+//    let button = UIButton(configuration: configuration)
+//    return button.set {
+//      $0.setImage(UIImage(systemName: "chevron.down")?.withConfiguration(UIImage.SymbolConfiguration(pointSize: 10)), for: .normal)
+//      $0.semanticContentAttribute = .forceRightToLeft
+//    }
+//  }()
+  
+//  private var selectedCountry: String?
   
   // MARK: - OnAction
-  var onActionChangeCountry: ((String) -> Void)?
+//  var onActionChangeCountry: ((String) -> Void)?
   
   // MARK: - Initializers
   override init(frame: CGRect) {
@@ -56,7 +61,7 @@ class CountrySelector: UIView {
     addSubview(contentStack)
     
     contentStack.addArrangedSubview(titleLabel)
-    contentStack.addArrangedSubview(countryButton)
+    contentStack.addArrangedSubview(countryLabel)
   }
   
   private func setupConstraints() {
@@ -69,42 +74,19 @@ class CountrySelector: UIView {
   }
   
   // MARK: - Configuration
-  func configure(countries: [String], selectedCountry: String) {
-    self.selectedCountry = selectedCountry
-    self.countryButton.setTitle(selectedCountry, for: .normal)
-    self.countryButton.akFont(.gmarketBold16)
-    
-    setupMenu(countries)
-  }
-  
-  private func setupMenu(_ countries: [String]) {
-    let menu = UIMenu(
-      title: "", 
-      children: countries.map { country in
-        UIAction(
-          title: country,
-          image: country == self.selectedCountry ? UIImage(systemName: "checkmark") : nil,
-          handler: { [weak self] _ in
-            guard let self else { return }
-            self.countryButton.setTitle(country, for: .normal)
-            self.countryButton.akFont(.gmarketBold16)
-            self.selectedCountry = country
-            self.setupMenu(countries)
-            self.onActionChangeCountry?(country)
-          }
-        )
-      }
-    )
-    
-    countryButton.menu = menu
-    countryButton.showsMenuAsPrimaryAction = true
+  func configure(selectedCountry: String) {
+//    self.selectedCountry = selectedCountry
+    self.countryLabel.text = selectedCountry
+//    self.countryLabel.setTitle(selectedCountry, for: .normal)
+//    self.countryLabel.akFont(.gmarketBold16)
+//    
+//    setupMenu(countries)
   }
 }
 
 #Preview {
   let countrySelector = CountrySelector()
   countrySelector.configure(
-    countries: ["베트남", "스위스"],
     selectedCountry: "베트남"
   )
   

--- a/AKCOO/Scene/JudgmentScene/View/Paper/OpenedPaperView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Paper/OpenedPaperView.swift
@@ -196,7 +196,6 @@ class OpenedPaperView: UIView {
     self.selectedCategory = selectedCategory
 
     countrySelector.configure(
-      countries: paperModel.countries.map { $0 },
       selectedCountry: paperModel.selectedCountryProfile.name
     )
     
@@ -228,11 +227,9 @@ class OpenedPaperView: UIView {
   }
   
   func onActionChange(
-    country: @escaping ((String) -> Void),
     category: @escaping ((String?) -> Void),
     amount: @escaping ((String?) -> Void)
   ) {
-    countrySelector.onActionChangeCountry = country
     categorySelector.onActionChangeCategory = category
     amountTextField.onActionValidAmountInput = amount
   }
@@ -272,7 +269,6 @@ class OpenedPaperView: UIView {
         name: "베트남",
         currency: .init(unitTitle: "동", unit: 0.05539)
       ),
-      countries: ["베트남", "스위스"],
       categories: ["가나", "나", "다"]
     ),
     previousRecordExists: false


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #87 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

```swift 
private func configureButton(selectedCountry: String) {
    let attributedString = NSAttributedString(
      string: selectedCountry,
      attributes: [
        .underlineStyle: NSUnderlineStyle.single.rawValue,
        .font: UIFont.akFont(.gmarketBold30) as Any,
        .baselineOffset: 8
      ]
    )
    
    countryButton.setAttributedTitle(attributedString, for: .normal)
  }
```
밑줄, 폰트, 텍스트 설정을 버튼의 `NSAttributedString` 을 설정함으로서 적용되도록 구성하였습니다   
메뉴에서 값이 선택될 때 마다 새로  `NSAttributedString`를 생성하여 대입합니다   
이 과정은 위의 메서드를 통해 재사용됩니다! 

### 선택된 국가와 국가 리스트 반영 시점 

```swift 
class GuideViewController: UIViewController {
  weak var coordinator: GuideCoordinator?
  private let guideUseCase: GuideUseCase
  
  // MARK: View
  private var guideView: GuideView! {
    return view as? GuideView
  }
  
  private var selectedCountry: String = ""
  
  init(guideUseCase: GuideUseCase) {
    self.guideUseCase = guideUseCase
    super.init(nibName: nil, bundle: nil)
    
    selectedCountry = "스위스" // CountryDetail 받아올 때 초기화
  }
```
 선택된 국가는 GuideViewController 실행시 `CountryDetail`로 부터 추출하기를 기대하고 있습니다   
(이 부분은 스크롤 화면 구현하며 구체화 될 것 같아 당장 작성하지 않았습니다)      

<img width="232" alt="image" src="https://github.com/user-attachments/assets/316eb10b-ed99-4189-9b2a-a9c202a79b39">

또한 `Menu` 구성에 필요한 CountryList는 configure 메서드 실행 시 UseCase에서 호출 받도록 작성하였습니다    

```swift 
  override func viewDidLoad() {
    super.viewDidLoad()
    
    configure()
    onAction()
  }
  
  private func configure() {
    guard case let .success(countries) = guideUseCase.getCountryNames() else { return } // 예외처리
    guideView.configure(countries: countries, selectedCountry: selectedCountry)
  }
```

### 국가 변경 시 데이터 초기화 

```swift 
guideView.countrySelectorTitle.onActionChangeCountry = { [weak self] newCountry in
      guard let self else { return }
      _ = self.guideUseCase.getNewCountryDetail(newCountryName: newCountry)
      // selectedCountry 도 변경
    }
```    

해당 코드는 ViewController onAction 메서드 내에 있습니다    
ViewController에서 guideView.countrySelectorTitle.onActionChangeCountry  
직접 하위 뷰의 하위 뷰 액션에 접근해도 괜찮은가? 에 대한 고민을 해 보았습니다    
우선 이렇게 작성할 시 guideView가 상위 뷰에 제공할 수 있는 action을 가공해서 제공해 주지 않으므로 사용단에서 
직접 찍어가며 확인해야 한다는 단점이 있었습니다 (책임 불명확)  
하지만 당장 생각하기에는, guideView는 묶음 뷰일 뿐 특정 화면에 대한 책임을 지니고 있다고 보기 어려울 수도 있겠다 판단하였습니다      
더 나아가 하나의 action을 전달하기 위해 그를 거쳐가는 중간 View들에 매번 Action 메서드를 작성하는 작업에 대해 다시 한 번 고민해 보아도 좋을 것 같다는 생각이 들었습니다! (공수가 들기 때문입니다) 

(하지만 여전히 역할을 명확히 하기 위해 onAction 메서드를 빼는 게 좋다고도 생각합니다!)   
(당장은 급한 일정을 따라 합리적으로 판단하였습니다)   


### `OpendPaperView`에 존재하던 국가 선택 화면 삭제 

<img width="378" alt="image" src="https://github.com/user-attachments/assets/fc6473b7-89ad-4bbc-b532-c90824bb73bd">

### `OpendPaperView`에 존재하던 국가 선택 기능 삭제   
`JudgmentUseCase`를 다듬고 `GuideUseCase`를 재정의 하였습니다    
`JudgmentUseCase`는 하나의 CountryDetail에 대한 처리를 수행하므로 [CountryDetail] 관리 코드를 삭제하였습니다   

더 나아가, 테스트 용이성을 위해, 각 func 이 순서에 의존하지 않도록 `JudgmentUseCase`가 소유하고 있는 상태값을 파라미터로 전달 받을 수 있게 변경하였습니다     



<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

<img width="298" alt="image" src="https://github.com/user-attachments/assets/bcd0fcdd-cdf4-455e-8fd2-925ee06622bb">


<img width="216" alt="image" src="https://github.com/user-attachments/assets/e088f833-7490-458b-85ac-190a5d8bc0df">


<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->   

기존 JudgmentViewController 에 존재하던 국가 선택을 없애는 것 또한 진행하고자 하였지만   
디자인 협의가 이루어지지 않아 우선 보류하고자 합니다! 


<br>
