### PR TITLE
🐛 Fix: 사용자 판단이 중복 저장되는 문제 해결

### DIFF
--- a/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentView.swift
+++ b/AKCOO/Scene/JudgmentScene/View/Judgment/JudgmentView.swift
@@ -209,19 +209,19 @@ class JudgmentView: UIView {
   
   private func fadeOutAndTransition() {
     UIView.animate(withDuration: 1.3, animations: {
-          // 뷰의 투명도를 0으로 설정 (페이드 아웃 효과)
-        self.paper.alpha = 0.0
-        self.birdsReactionTitleLabel.alpha = 0.0
-        self.paperTitleLabel.alpha = 0.0
-        self.reactionCollectionView.alpha = 0.0
-        self.decisionLabel.alpha = 0.0
-        self.decisionStack.alpha = 0.0
-        self.gradientView.alpha = 0.0
-        
-      }, completion: { _ in
-          // 애니메이션 완료 후 화면 전환 처리
-          self.onActionCompletedDecision?(true) // 화면 전환 로직
-      })
+      // 뷰의 투명도를 0으로 설정 (페이드 아웃 효과)
+      self.paper.alpha = 0.0
+      self.birdsReactionTitleLabel.alpha = 0.0
+      self.paperTitleLabel.alpha = 0.0
+      self.reactionCollectionView.alpha = 0.0
+      self.decisionLabel.alpha = 0.0
+      self.decisionStack.alpha = 0.0
+      self.gradientView.alpha = 0.0
+      
+    }, completion: { _ in
+      // 애니메이션 완료 후 화면 전환 처리
+//      self.onActionCompletedDecision?(true) // 화면 전환 로직
+    })
   }
 }
 

--- a/AKCOO/Scene/UserInfoScene/View/UserInfoDescriptionView.swift
+++ b/AKCOO/Scene/UserInfoScene/View/UserInfoDescriptionView.swift
@@ -102,7 +102,7 @@ class UserInfoDescriptionView: UIView {
     )
     
     // 2. Bold 스타일 적용
-    let boldPatterns = ["\\s*.+짹짹이"]
+    let boldPatterns = ["\\s*.+짹짹이", "지출 판단을 시작하세요"]
     let boldRegexes = boldPatterns.map { try? NSRegularExpression(pattern: $0) }
     
     boldRegexes.forEach { regex in

--- a/AKCOO/Scene/UserInfoScene/View/UserInfoRecordsView.swift
+++ b/AKCOO/Scene/UserInfoScene/View/UserInfoRecordsView.swift
@@ -30,11 +30,23 @@ struct UserInfoRecordsView: View {
       
       LazyVStack(spacing: 10) {
         if viewModel.userRecords.isEmpty {
-          HStack {
-            Spacer()
-            Text("아직 지출 판단 기록이 없어요")
-              .multilineTextAlignment(.center)
-            Spacer()
+          VStack(spacing: 10) {
+            HStack {
+              Text("아직 기록이 없어요")
+              Spacer()
+            }
+            .padding(.horizontal, 8)
+            
+            Line()
+              .stroke(
+                style: StrokeStyle(
+                  lineWidth: 0.4,       // 선 두께
+                  dash: [4, 2],         // 대시 패턴: [대시 길이, 간격]
+                  dashPhase: 0          // 대시 시작 위치
+                )
+              )
+              .foregroundColor(.black)  // 선 색상
+              .frame(height: 1)         // 선 높이 조정
           }
         } else {
           ForEach(viewModel.userRecords, id: \.id) { record in


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #97 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

- 사용자 판단 기록이 중복 저장되는 문제를 해결했습니다.
- 사용자 판단 유형 화면에서 변경된 부분을 추가했습니다.

<br>


## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
- JudgmentView의 fadeOutAndTransition() 내부에 저장하는 코드를 주석처리해두었습니다.
  혹시 변경이 필요하면 알려주세요!

<br>
